### PR TITLE
Deep links and rule evaluation fixes for event parameters

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -31,10 +31,19 @@
 
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
+
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
+                <data android:scheme="superapp" />
+            </intent-filter>
         </activity>
         <activity
             android:name="com.superwall.sdk.paywall.vc.SuperwallPaywallActivity"
-            android:configChanges="orientation|screenSize|keyboardHidden"></activity>
+            android:configChanges="orientation|screenSize|keyboardHidden">
+        </activity>
     </application>
-
 </manifest>

--- a/app/src/main/java/com/superwall/superapp/MainActivity.kt
+++ b/app/src/main/java/com/superwall/superapp/MainActivity.kt
@@ -1,14 +1,19 @@
 package com.superwall.superapp
 
 import android.content.Intent
+import android.net.Uri
 import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
 import android.widget.Button
+import com.superwall.sdk.Superwall
 
 class MainActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
+
+        // Setup deep linking handling
+        respondToDeepLinks()
 
         // campaign_trigger
         val campaignTriggerButton: Button = findViewById(R.id.campaignTriggerButton)
@@ -55,4 +60,14 @@ class MainActivity : AppCompatActivity() {
             startActivity(intent)
         }
     }
+
+    //region Deep Links
+
+    private fun respondToDeepLinks() {
+        intent?.data?.let { uri ->
+            Superwall.instance.handleDeepLink(uri)
+        }
+    }
+
+    //endregion
 }

--- a/superwall/src/main/java/com/superwall/sdk/analytics/internal/Tracking.kt
+++ b/superwall/src/main/java/com/superwall/sdk/analytics/internal/Tracking.kt
@@ -18,6 +18,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
+import org.json.JSONObject
 import java.util.*
 
 suspend fun Superwall.track(event: Trackable): TrackingResult {
@@ -49,7 +50,7 @@ suspend fun Superwall.track(event: Trackable): TrackingResult {
 
     val eventData = EventData(
         name = event.rawName,
-        parameters = parameters.eventParams,
+        parameters = JSONObject(parameters.eventParams),
         createdAt = eventCreatedAt
     )
     dependencyContainer.queue.enqueue(event = eventData)

--- a/superwall/src/main/java/com/superwall/sdk/analytics/superwall/SuperwallEvent.kt
+++ b/superwall/src/main/java/com/superwall/sdk/analytics/superwall/SuperwallEvent.kt
@@ -1,5 +1,6 @@
 package com.superwall.sdk.analytics.superwall
 
+import android.net.Uri
 import com.superwall.sdk.models.triggers.TriggerResult
 import com.superwall.sdk.paywall.presentation.PaywallInfo
 import com.superwall.sdk.paywall.presentation.internal.PaywallPresentationRequestStatus
@@ -67,7 +68,7 @@ sealed class SuperwallEvent {
     /// When a user opens the app via a deep link.
     ///
     /// The raw value of this event can be added to a campaign to trigger a paywall.
-    data class DeepLink(val url: URL) : SuperwallEvent() {
+    data class DeepLink(val uri: Uri) : SuperwallEvent() {
         override val rawName: String
             get() = "deepLink_open"
     }

--- a/superwall/src/main/java/com/superwall/sdk/dependencies/FactoryProtocols.kt
+++ b/superwall/src/main/java/com/superwall/sdk/dependencies/FactoryProtocols.kt
@@ -1,5 +1,6 @@
 package com.superwall.sdk.dependencies
 
+import ComputedPropertyRequest
 import android.app.Activity
 import com.android.billingclient.api.Purchase
 import com.superwall.sdk.analytics.trigger_session.TriggerSessionManager
@@ -17,17 +18,16 @@ import com.superwall.sdk.paywall.presentation.internal.PresentationRequest
 import com.superwall.sdk.paywall.presentation.internal.PresentationRequestType
 import com.superwall.sdk.paywall.presentation.internal.request.PaywallOverrides
 import com.superwall.sdk.paywall.presentation.internal.request.PresentationInfo
-import com.superwall.sdk.paywall.presentation.rule_logic.RuleAttributes
 import com.superwall.sdk.paywall.request.PaywallRequest
 import com.superwall.sdk.paywall.request.ResponseIdentifiers
 import com.superwall.sdk.paywall.vc.PaywallViewController
 import com.superwall.sdk.paywall.vc.delegate.PaywallViewControllerDelegate
-import com.superwall.sdk.paywall.vc.web_view.templating.models.OuterVariables
 import com.superwall.sdk.storage.Storage
 import com.superwall.sdk.store.abstractions.transactions.StoreTransactionType
 import com.superwall.sdk.store.coordinator.StoreKitCoordinator
 import com.superwall.sdk.store.transactions.purchasing.PurchaseManager
 import kotlinx.coroutines.flow.StateFlow
+import org.json.JSONObject
 
 
 interface ApiFactory {
@@ -81,7 +81,10 @@ interface RequestFactory {
 
 
 interface RuleAttributesFactory {
-    suspend fun makeRuleAttributes(): RuleAttributes
+    suspend fun makeRuleAttributes(
+        event: EventData?,
+        computedPropertyRequests: List<ComputedPropertyRequest>
+    ): JSONObject
 }
 
 interface IdentityInfoFactory {
@@ -136,8 +139,9 @@ interface CacheFactory {
 interface VariablesFactory {
     suspend fun makeJsonVariables(
         productVariables: List<ProductVariable>?,
-        params: Map<String, Any?>?
-    ): OuterVariables
+        computedPropertyRequests: List<ComputedPropertyRequest>,
+        event: EventData?
+    ): JSONObject
 }
 
 interface ConfigManagerFactory {

--- a/superwall/src/main/java/com/superwall/sdk/misc/JSONObjectHelpers.kt
+++ b/superwall/src/main/java/com/superwall/sdk/misc/JSONObjectHelpers.kt
@@ -1,0 +1,49 @@
+package com.superwall.sdk.misc
+
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.descriptors.PrimitiveKind
+import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+import org.json.JSONArray
+import org.json.JSONObject
+
+fun JSONObject.toMap(): Map<String, Any?> {
+    val map = mutableMapOf<String, Any?>()
+    for (key in this.keys()) {
+        val value = this.opt(key)  // opt() gets the value or null if the key does not exist
+        when {
+            value == JSONObject.NULL -> map[key] = null
+            value is JSONObject -> map[key] = value.toMap()
+            value is JSONArray -> map[key] = value.toList()
+            else -> map[key] = value
+        }
+    }
+    return map
+}
+
+fun JSONArray.toList(): List<Any?> {
+    return (0 until this.length()).map { idx ->
+        val value = this.opt(idx)  // opt() gets the value or null if the index is out-of-bounds
+        when {
+            value == JSONObject.NULL -> null
+            value is JSONObject -> value.toMap()
+            value is JSONArray -> value.toList()
+            else -> value
+        }
+    }
+}
+
+
+object JSONObjectSerializer : KSerializer<JSONObject> {
+    override val descriptor: SerialDescriptor = PrimitiveSerialDescriptor("JSONObject", PrimitiveKind.STRING)
+
+    override fun serialize(encoder: Encoder, value: JSONObject) {
+        encoder.encodeString(value.toString())
+    }
+
+    override fun deserialize(decoder: Decoder): JSONObject {
+        return JSONObject(decoder.decodeString())
+    }
+}

--- a/superwall/src/main/java/com/superwall/sdk/models/config/ComputedPropertyRequest.kt
+++ b/superwall/src/main/java/com/superwall/sdk/models/config/ComputedPropertyRequest.kt
@@ -1,0 +1,54 @@
+import kotlinx.serialization.Serializable
+import java.util.Calendar
+import java.util.Date
+
+/**
+ * A request to compute a device property associated with an event at runtime.
+ */
+@Serializable
+data class ComputedPropertyRequest(
+    val type: ComputedPropertyRequestType,
+    val eventName: String
+) {
+    /**
+     * The type of device property to compute.
+     */
+    enum class ComputedPropertyRequestType(val rawValue: String) {
+        MINUTES_SINCE("MINUTES_SINCE"),
+        HOURS_SINCE("HOURS_SINCE"),
+        DAYS_SINCE("DAYS_SINCE"),
+        MONTHS_SINCE("MONTHS_SINCE"),
+        YEARS_SINCE("YEARS_SINCE");
+
+        val prefix: String
+            get() = when (this) {
+                MINUTES_SINCE -> "minutesSince_"
+                HOURS_SINCE -> "hoursSince_"
+                DAYS_SINCE -> "daysSince_"
+                MONTHS_SINCE -> "monthsSince_"
+                YEARS_SINCE -> "yearsSince_"
+            }
+
+        val calendarComponent: Int
+            get() = when (this) {
+                MINUTES_SINCE -> Calendar.MINUTE
+                HOURS_SINCE -> Calendar.HOUR
+                DAYS_SINCE -> Calendar.DAY_OF_MONTH
+                MONTHS_SINCE -> Calendar.MONTH
+                YEARS_SINCE -> Calendar.YEAR
+            }
+
+        fun dateComponent(date: Date): Int {
+            val calendar = Calendar.getInstance()
+            calendar.time = date
+            return calendar.get(calendarComponent)
+        }
+
+        companion object {
+            fun fromRawValue(value: String): ComputedPropertyRequestType? {
+                return values().find { it.rawValue == value }
+                    ?: throw IllegalArgumentException("Unsupported computed property type.")
+            }
+        }
+    }
+}

--- a/superwall/src/main/java/com/superwall/sdk/models/events/EventData.kt
+++ b/superwall/src/main/java/com/superwall/sdk/models/events/EventData.kt
@@ -1,5 +1,6 @@
 package com.superwall.sdk.models.events
 
+import com.superwall.sdk.misc.JSONObjectSerializer
 import com.superwall.sdk.models.serialization.AnyMapSerializer
 import com.superwall.sdk.models.serialization.AnySerializer
 import com.superwall.sdk.models.serialization.DateSerializer
@@ -11,91 +12,29 @@ import kotlinx.serialization.encoding.CompositeDecoder
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
 import kotlinx.serialization.json.JsonElement
+import org.json.JSONObject
 import java.util.*
 
-
-//object EventDataSerializer: KSerializer<EventData>  {
-//    @OptIn(InternalSerializationApi::class)
-//    override val descriptor: SerialDescriptor = buildSerialDescriptor("EventData", StructureKind.OBJECT)
-//
-//    override fun deserialize(decoder: Decoder): EventData {
-//        TODO("Not yet implemented")
-//    }
-//
-//    override fun serialize(encoder: Encoder, value: EventData) {
-//        TODO("Not yet implemented")
-//    }
-//
-//}
-
-object EventDataSerializer : KSerializer<EventData> {
-    override val descriptor: SerialDescriptor
-        get() = buildClassSerialDescriptor("EventData") {
-            element<String>("event_id")
-            element<String>("event_name")
-            element<Map<String, JsonElement>>("parameters")
-            element<JsonElement>("createdAt")
-        }
-
-    override fun serialize(encoder: Encoder, value: EventData) {
-        val compositeEncoder = encoder.beginStructure(descriptor)
-        compositeEncoder.encodeStringElement(descriptor, 0, value.id)
-        compositeEncoder.encodeStringElement(descriptor, 1, value.name)
-        compositeEncoder.encodeSerializableElement(
-            descriptor,
-            2,
-            AnyMapSerializer,
-            value.parameters
-        )
-        compositeEncoder.encodeSerializableElement(descriptor, 3, DateSerializer, value.createdAt)
-        compositeEncoder.endStructure(descriptor)
-    }
-
-    override fun deserialize(decoder: Decoder): EventData {
-        lateinit var id: String
-        lateinit var name: String
-        lateinit var parameters: Map<String, Any>
-        lateinit var createdAt: Date
-
-        val dec: CompositeDecoder = decoder.beginStructure(descriptor)
-        loop@ while (true) {
-            when (val i = dec.decodeElementIndex(descriptor)) {
-                CompositeDecoder.DECODE_DONE -> break@loop
-                0 -> id = dec.decodeStringElement(descriptor, i)
-                1 -> name = dec.decodeStringElement(descriptor, i)
-                2 -> parameters = dec.decodeSerializableElement(
-                    descriptor,
-                    i,
-                    MapSerializer(String.serializer(), AnySerializer)
-                )
-                3 -> createdAt = dec.decodeSerializableElement(descriptor, i, DateSerializer)
-                else -> throw SerializationException("Unknown index $i")
-            }
-        }
-        dec.endStructure(descriptor)
-        return EventData(id, name, parameters, createdAt)
-    }
-}
-
-
-@kotlinx.serialization.Serializable(with = EventDataSerializer::class)
+@kotlinx.serialization.Serializable
 data class EventData(
     @SerialName("event_id")
-    var id: String = UUID.randomUUID().toString(),
+    val id: String = UUID.randomUUID().toString(),
     @SerialName("event_name")
-    var name: String,
-    var parameters: Map<String, @Serializable(with = AnySerializer::class) Any?>,
+    val name: String,
+    @Serializable(with = JSONObjectSerializer::class)
+    val parameters: JSONObject,
     @Serializable(with = DateSerializer::class)
-    var createdAt: Date,
+    val createdAt: Date,
 ) {
 
     companion object {
         fun stub(): EventData {
             return EventData(
                 name = "opened_application",
-                parameters = mapOf<String, Any>(),
+                parameters = JSONObject(),
                 createdAt = Date()
             )
         }
     }
 }
+

--- a/superwall/src/main/java/com/superwall/sdk/models/paywall/Paywall.kt
+++ b/superwall/src/main/java/com/superwall/sdk/models/paywall/Paywall.kt
@@ -1,5 +1,6 @@
 package com.superwall.sdk.models.paywall
 
+import ComputedPropertyRequest
 import com.superwall.sdk.dependencies.TriggerSessionManagerFactory
 import com.superwall.sdk.models.SerializableEntity
 import com.superwall.sdk.models.config.FeatureGatingBehavior
@@ -56,6 +57,9 @@ data class Paywall(
     var paywalljsVersion: String? = null,
     var isFreeTrialAvailable: Boolean = false,
     var featureGating: FeatureGatingBehavior = FeatureGatingBehavior.NonGated,
+
+    @SerialName("computedProperties")
+    var computedPropertyRequests: List<ComputedPropertyRequest> = emptyList(),
 
     @kotlinx.serialization.Transient()
     var experiment: Experiment? = null,

--- a/superwall/src/main/java/com/superwall/sdk/models/product/ProductVariable.kt
+++ b/superwall/src/main/java/com/superwall/sdk/models/product/ProductVariable.kt
@@ -1,10 +1,13 @@
 package com.superwall.sdk.models.product
 
+import com.superwall.sdk.misc.JSONObjectSerializer
 import com.superwall.sdk.models.serialization.AnySerializer
 import kotlinx.serialization.Serializable
+import org.json.JSONObject
 
 @Serializable
 data class ProductVariable(
     val type: ProductType,
-    val attributes: Map<String, @Serializable(with = AnySerializer::class) Any> // Assuming JSON as Map<String, Any>
+    @Serializable(with = JSONObjectSerializer::class)
+    val attributes: JSONObject
 )

--- a/superwall/src/main/java/com/superwall/sdk/models/triggers/TriggerRule.kt
+++ b/superwall/src/main/java/com/superwall/sdk/models/triggers/TriggerRule.kt
@@ -1,5 +1,7 @@
 package com.superwall.sdk.models.triggers
 
+import ComputedPropertyRequest
+import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
@@ -7,10 +9,11 @@ data class TriggerRule(
     var experimentId: String,
     var experimentGroupId: String,
     var variants: List<VariantOption>,
-
     val expression: String? = null,
     val expressionJs: String? = null,
-    val occurrence: TriggerRuleOccurrence? = null
+    val occurrence: TriggerRuleOccurrence? = null,
+    @SerialName("computedProperties")
+    val computedPropertyRequests: List<ComputedPropertyRequest> = emptyList()
 ) {
 
     val experiment: RawExperiment
@@ -36,7 +39,8 @@ data class TriggerRule(
             ),
             expression = null,
             expressionJs = null,
-            occurrence = null
+            occurrence = null,
+            computedPropertyRequests = emptyList()
         )
     }
 }

--- a/superwall/src/main/java/com/superwall/sdk/paywall/presentation/internal/operators/EvaluateRules.kt
+++ b/superwall/src/main/java/com/superwall/sdk/paywall/presentation/internal/operators/EvaluateRules.kt
@@ -24,7 +24,7 @@ suspend fun Superwall.evaluateRules(
     val eventData = request.presentationInfo.eventData
     return if (eventData != null) {
         val assignmentLogic = RuleLogic(
-            context = contex,
+            context = context,
             configManager = dependencyContainer.configManager,
             storage = dependencyContainer.storage,
             factory = dependencyContainer

--- a/superwall/src/main/java/com/superwall/sdk/paywall/presentation/rule_logic/expression_evaluator/ExpressionEvaluator.kt
+++ b/superwall/src/main/java/com/superwall/sdk/paywall/presentation/rule_logic/expression_evaluator/ExpressionEvaluator.kt
@@ -93,17 +93,13 @@ class ExpressionEvaluator(
     }
 
     private suspend fun getPostfix(rule: TriggerRule, eventData: EventData): String? {
-        val ruleAttributes = factory.makeRuleAttributes()
-        val jsonValues = JSONObject()
-        jsonValues.put("user", JSONObject(ruleAttributes.user))
-        jsonValues.put("device", JSONObject(ruleAttributes.device))
-        jsonValues.put("params", JSONObject(eventData.parameters))
+        val jsonAttributes = factory.makeRuleAttributes(event = eventData, computedPropertyRequests = rule.computedPropertyRequests)
 
         return when {
             rule.expressionJs != null -> {
                 val base64Params = JavascriptExpressionEvaluatorParams(
                     expressionJs = rule.expressionJs,
-                    values = jsonValues
+                    values = jsonAttributes
                 ).toBase64Input()
 
 
@@ -112,7 +108,7 @@ class ExpressionEvaluator(
             rule.expression != null -> {
                 val base64Params = LiquidExpressionEvaluatorParams(
                     expression = rule.expression,
-                    values = jsonValues
+                    values = jsonAttributes
                 ).toBase64Input()
 
                 base64Params?.let { "\n SuperwallSDKJS.evaluate64('$it');" }

--- a/superwall/src/main/java/com/superwall/sdk/paywall/request/PaywallLogic.kt
+++ b/superwall/src/main/java/com/superwall/sdk/paywall/request/PaywallLogic.kt
@@ -10,6 +10,7 @@ import com.superwall.sdk.models.product.Product
 import com.superwall.sdk.models.product.ProductVariable
 import com.superwall.sdk.models.triggers.Experiment
 import com.superwall.sdk.store.abstractions.product.StoreProduct
+import org.json.JSONObject
 
 data class ResponseIdentifiers(
     val paywallId: String?,
@@ -105,7 +106,7 @@ object PaywallLogic {
 
             val productVariable = ProductVariable(
                 type = product.type,
-                attributes = storeProduct.attributes
+                attributes = JSONObject(storeProduct.attributes)
             )
             productVariables.add(productVariable)
 

--- a/superwall/src/main/java/com/superwall/sdk/paywall/vc/PaywallViewController.kt
+++ b/superwall/src/main/java/com/superwall/sdk/paywall/vc/PaywallViewController.kt
@@ -248,12 +248,6 @@ class PaywallViewController(
             }
         )
         alertController.show()
-
-        // TODO: Not sure why the iOS SDK does this...
-        if (loadingState != PaywallLoadingState.LoadingURL()) {
-            this.loadingState = PaywallLoadingState.Ready()
-        }
-
     }
 
     //endregion

--- a/superwall/src/main/java/com/superwall/sdk/paywall/vc/web_view/messaging/PaywallMessageHandler.kt
+++ b/superwall/src/main/java/com/superwall/sdk/paywall/vc/web_view/messaging/PaywallMessageHandler.kt
@@ -102,10 +102,10 @@ class PaywallMessageHandler(
     // Passes the templated variables and params to the webview.
 // This is called every paywall open incase variables like user attributes have changed.
     private suspend fun passTemplatesToWebView(paywall: Paywall) {
-        val params = delegate?.request?.presentationInfo?.eventData?.parameters
+        val eventData = delegate?.request?.presentationInfo?.eventData
         val templates = TemplateLogic.getBase64EncodedTemplates(
             paywall = paywall,
-            params = params,
+            event = eventData,
             factory = factory
         )
 
@@ -160,10 +160,10 @@ class PaywallMessageHandler(
         println("!! PaywallMessageHandler: didLoadWebView")
 
         val htmlSubstitutions = paywall.htmlSubstitutions
-        val params = delegate?.request?.presentationInfo?.eventData?.parameters
+        val eventData = delegate?.request?.presentationInfo?.eventData
         val templates = TemplateLogic.getBase64EncodedTemplates(
             paywall = paywall,
-            params = params,
+            event = eventData,
             factory = factory
         )
         val scriptSrc = """

--- a/superwall/src/main/java/com/superwall/sdk/paywall/vc/web_view/templating/TemplateLogic.kt
+++ b/superwall/src/main/java/com/superwall/sdk/paywall/vc/web_view/templating/TemplateLogic.kt
@@ -1,4 +1,6 @@
 import com.superwall.sdk.dependencies.VariablesFactory
+import com.superwall.sdk.misc.JSONObjectSerializer
+import com.superwall.sdk.models.events.EventData
 import com.superwall.sdk.models.paywall.Paywall
 import com.superwall.sdk.paywall.vc.web_view.templating.models.FreeTrialTemplate
 import com.superwall.sdk.paywall.view_controller.web_view.templating.models.ProductTemplate
@@ -9,7 +11,7 @@ import java.util.*
 object TemplateLogic {
     suspend fun getBase64EncodedTemplates(
         paywall: Paywall,
-        params: Map<String, Any?>?,
+        event: EventData?,
         factory: VariablesFactory
     ): String {
         val productsTemplate = ProductTemplate(
@@ -19,7 +21,8 @@ object TemplateLogic {
 
         val variablesTemplate = factory.makeJsonVariables(
             productVariables = paywall.productVariables,
-            params = params
+            computedPropertyRequests = paywall.computedPropertyRequests,
+            event = event
         )
 
         val freeTrialTemplate = FreeTrialTemplate(
@@ -35,7 +38,7 @@ object TemplateLogic {
 
         val encodedTemplates = listOf(
             json.encodeToString(productsTemplate),
-            json.encodeToString(variablesTemplate),
+            json.encodeToString(JSONObjectSerializer, variablesTemplate),
             json.encodeToString(freeTrialTemplate),
 //            json.encodeToString(swProductTemplate)
         )

--- a/superwall/src/main/java/com/superwall/sdk/paywall/vc/web_view/templating/models/Variables.kt
+++ b/superwall/src/main/java/com/superwall/sdk/paywall/vc/web_view/templating/models/Variables.kt
@@ -1,50 +1,59 @@
 package com.superwall.sdk.paywall.vc.web_view.templating.models
 
+import com.superwall.sdk.misc.toMap
 import com.superwall.sdk.models.product.ProductType
 import com.superwall.sdk.models.product.ProductVariable
 import com.superwall.sdk.models.serialization.AnySerializer
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.modules.SerializersModule
+import org.json.JSONObject
 
-
-@kotlinx.serialization.Serializable
-class OuterVariables(
-    val event_name: String = "template_variables",
-    val variables: Variables
-)
-
-
-@kotlinx.serialization.Serializable
-class Variables(
-    val user: Map<String, @kotlinx.serialization.Serializable(with = AnySerializer::class) Any?>,
-    val primary: Map<String, @kotlinx.serialization.Serializable(with = AnySerializer::class) Any?>?,
-    val secondary: Map<String, @kotlinx.serialization.Serializable(with = AnySerializer::class) Any?>?,
-    val tertiary: Map<String, @kotlinx.serialization.Serializable(with = AnySerializer::class) Any?>?,
-//    val device: Map<String, @kotlinx.serialization.Serializable(with = AnySerializer::class) Any?>,
-    val device: DeviceTemplate,
-    val params: Map<String, @kotlinx.serialization.Serializable(with = AnySerializer::class) Any?>,
+data class Variables(
+    val user: JSONObject,
+    val device: JSONObject,
+    val params: JSONObject,
+    var primary: JSONObject = JSONObject(),
+    var secondary: JSONObject = JSONObject(),
+    var tertiary: JSONObject = JSONObject()
 ) {
-
-    companion object {
-        fun fromProperties(
-            productVariables: List<ProductVariable>,
-            params: Map<String, Any?>,
-            userAttributes: Map<String, Any?>,
-            templateDeviceDictionary: DeviceTemplate
-        ): OuterVariables {
-            val primary = productVariables.firstOrNull { it.type == ProductType.PRIMARY }
-            val secondary = productVariables.firstOrNull { it.type == ProductType.SECONDARY }
-            val tertiary = productVariables.firstOrNull { it.type == ProductType.TERTIARY }
-
-            return OuterVariables(
-                variables = Variables(
-                    user = userAttributes,
-                    primary = primary?.attributes,
-                    secondary = secondary?.attributes,
-                    tertiary = tertiary?.attributes,
-                    device = templateDeviceDictionary,
-                    params = params
-                ),
-                event_name = "template_variables"
-            )
+    constructor(
+        productVariables: List<ProductVariable>?,
+        params: JSONObject?,
+        userAttributes: Map<String, Any>,
+        templateDeviceDictionary: Map<String, Any>?
+    ) : this(
+        user = JSONObject(userAttributes),
+        device = JSONObject(templateDeviceDictionary ?: emptyMap<String, Any>()),
+        params = params ?: JSONObject()
+    ) {
+        productVariables?.forEach { productVariable ->
+            when (productVariable.type) {
+                ProductType.PRIMARY -> primary = productVariable.attributes
+                ProductType.SECONDARY -> secondary = productVariable.attributes
+                ProductType.TERTIARY -> tertiary = productVariable.attributes
+            }
         }
+    }
+
+    fun templated(): JSONObject {
+        val template = JSONObject()
+        template.put("event_name", "template_variables")
+
+        val dict = dictionary() ?: emptyMap<String, Any>()
+        template.put("variables", dict)
+
+        return template
+    }
+
+    private fun dictionary(): Map<String, Any?>? {
+        return mapOf(
+            "user" to user.toMap(),
+            "device" to device.toMap(),
+            "params" to params.toMap(),
+            "primary" to primary.toMap(),
+            "secondary" to secondary.toMap(),
+            "tertiary" to tertiary.toMap()
+        )
     }
 }

--- a/superwall/src/main/java/com/superwall/sdk/storage/core_data/CoreDataManager.kt
+++ b/superwall/src/main/java/com/superwall/sdk/storage/core_data/CoreDataManager.kt
@@ -1,5 +1,6 @@
 package com.superwall.sdk.storage.core_data
 
+import ComputedPropertyRequest
 import com.superwall.sdk.models.events.EventData
 import com.superwall.sdk.models.triggers.TriggerRuleOccurrence
 
@@ -26,6 +27,7 @@ interface CoreDataManagerInterface {
 }
 
 
+// TODO: https://linear.app/superwall/issue/SW-2346/[android]-coredatamanager-implementation
 class CoreDataManager : CoreDataManagerInterface {
     override fun saveEventData(
         eventData: EventData,
@@ -51,5 +53,15 @@ class CoreDataManager : CoreDataManagerInterface {
         // TODO: ?
         return 0
     }
+
+    suspend fun getComputedPropertySinceEvent(
+        event: EventData?,
+        request: ComputedPropertyRequest
+    ): Int? {
+        // TODO
+
+        return null
+    }
+
 
 }

--- a/superwall/src/main/java/com/superwall/sdk/store/StoreKitManager.kt
+++ b/superwall/src/main/java/com/superwall/sdk/store/StoreKitManager.kt
@@ -23,6 +23,7 @@ import com.superwall.sdk.store.coordinator.ProductsFetcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
+import org.json.JSONObject
 
 /*
 class StoreKitManager(private val context: Context) : StoreKitManagerInterface {
@@ -121,7 +122,10 @@ class StoreKitManager(
 
         val variables = paywall.products.mapNotNull { product ->
             output.productsById[product.id]?.let { storeProduct ->
-                ProductVariable(type = product.type, attributes = storeProduct.attributes)
+                ProductVariable(
+                    type = product.type,
+                    attributes = JSONObject(storeProduct.attributes)
+                )
             }
         }
 


### PR DESCRIPTION
- Adds support for deep links
- Adds `JSONObjectSerializer` to mirror `JSON` iOS functionality
- Replaces `Variables` class to mirror iOS struct
- Adds implementation for `makeRuleAttributes` in `DependencyContainer`
- Adds implementation for `ComputedPropertyRequest` class
- Adds implementation for `getDeviceAttributes` in `DeviceHelper`
- Fixes `getPostfix` in `ExpressionEvaluator`
- Simplifies `EventData` class
- Removes unnecessary code in `PaywallViewController` presentation func (confirmed with Yusuf)