### PR TITLE
feature/trigger-session-manager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The changelog for `Superwall`. Also see the [releases](https://github.com/superw
 
 ### Enhancements
 
+- Adds `trigger_session_id` to Superwall Events.
 - Resets the scroll position of the paywall on close.
 
 ### Fixes

--- a/app/src/main/java/com/superwall/superapp/test/UITestHandler.kt
+++ b/app/src/main/java/com/superwall/superapp/test/UITestHandler.kt
@@ -33,7 +33,6 @@ class UITestHandler {
             "Uses the identify function. Should see the name 'Jack' in the paywall."
         )
         suspend fun test0() {
-            // TODO: The name doesn't display
             Superwall.instance.identify(userId = "test0")
             Superwall.instance.setUserAttributes(attributes = mapOf("first_name" to "Jack"))
             Superwall.instance.register(event = "present_data")

--- a/superwall/build.gradle.kts
+++ b/superwall/build.gradle.kts
@@ -20,7 +20,7 @@ plugins {
 }
 
 
-version = "1.0.0-alpha.13"
+version = "1.0.0-alpha.14"
 
 android {
     compileSdk = 33

--- a/superwall/src/main/java/com/superwall/sdk/analytics/internal/trackable/TrackableSuperwallEvent.kt
+++ b/superwall/src/main/java/com/superwall/sdk/analytics/internal/trackable/TrackableSuperwallEvent.kt
@@ -20,7 +20,7 @@ import com.superwall.sdk.paywall.presentation.internal.PaywallPresentationReques
 import com.superwall.sdk.paywall.presentation.internal.PresentationRequestType
 import com.superwall.sdk.paywall.vc.Survey.SurveyPresentationResult
 import com.superwall.sdk.store.abstractions.product.StoreProduct
-import com.superwall.sdk.store.abstractions.transactions.GoogleBillingPurchaseTransaction
+import com.superwall.sdk.store.abstractions.transactions.StoreTransaction
 import com.superwall.sdk.store.abstractions.transactions.StoreTransactionType
 import com.superwall.sdk.store.transactions.TransactionError
 import kotlinx.serialization.json.*
@@ -359,7 +359,7 @@ sealed class InternalSuperwallEvent(override val superwallEvent: SuperwallEvent)
         val state: State,
         val paywallInfo: PaywallInfo,
         val product: StoreProduct?,
-        val model: StoreTransactionType?
+        val model: StoreTransaction?
     ) : TrackableSuperwallEvent {
         sealed class State {
             class Start(val product: StoreProduct) : State()
@@ -417,7 +417,7 @@ sealed class InternalSuperwallEvent(override val superwallEvent: SuperwallEvent)
                         val json = Json { encodeDefaults = true }
                         // TODO: Figure out how to get this to work with kotlinx.serialization
                         val jsonObject: JsonObject =
-                            json.encodeToJsonElement(model as GoogleBillingPurchaseTransaction).jsonObject
+                            json.encodeToJsonElement(model).jsonObject
 
                         val modelMap: Map<String, Any> = jsonObject.mapValues { entry ->
                             when (val value = entry.value) {

--- a/superwall/src/main/java/com/superwall/sdk/analytics/internal/trackable/TrackableSuperwallEvent.kt
+++ b/superwall/src/main/java/com/superwall/sdk/analytics/internal/trackable/TrackableSuperwallEvent.kt
@@ -239,7 +239,7 @@ sealed class InternalSuperwallEvent(override val superwallEvent: SuperwallEvent)
                 "trigger_name" to triggerName
             )
 
-            val triggerSessionId = sessionEventsManager.triggerSession.activeTriggerSession
+            val triggerSessionId = sessionEventsManager.triggerSession.getActiveTriggerSession()?.sessionId
             if (triggerSessionId != null) {
                 params["trigger_session_id"] = triggerSessionId
             }

--- a/superwall/src/main/java/com/superwall/sdk/analytics/trigger_session/TriggerSessionManager.kt
+++ b/superwall/src/main/java/com/superwall/sdk/analytics/trigger_session/TriggerSessionManager.kt
@@ -2,14 +2,18 @@ package com.superwall.sdk.analytics.trigger_session
 
 
 import android.app.Activity
+import com.superwall.sdk.Superwall
 import com.superwall.sdk.analytics.SessionEventsDelegate
 import com.superwall.sdk.analytics.SessionEventsManager
 import com.superwall.sdk.analytics.internal.TrackingResult
+import com.superwall.sdk.analytics.internal.track
+import com.superwall.sdk.analytics.internal.trackable.InternalSuperwallEvent
 import com.superwall.sdk.analytics.internal.trackable.Trackable
 import com.superwall.sdk.analytics.model.TriggerSession
 import com.superwall.sdk.analytics.session.AppSession
 import com.superwall.sdk.analytics.session.AppSessionManager
 import com.superwall.sdk.config.ConfigManager
+import com.superwall.sdk.delegate.SubscriptionStatus
 import com.superwall.sdk.identity.IdentityManager
 import com.superwall.sdk.models.config.Config
 import com.superwall.sdk.models.paywall.Paywall
@@ -18,6 +22,7 @@ import com.superwall.sdk.models.triggers.TriggerResult
 import com.superwall.sdk.paywall.presentation.internal.request.PresentationInfo
 import com.superwall.sdk.storage.Storage
 import com.superwall.sdk.store.abstractions.product.StoreProduct
+import java.util.UUID
 
 enum class LoadState {
     START,
@@ -33,12 +38,15 @@ class TriggerSessionManager(
     val appSessionManager: AppSessionManager,
     val identityManager: IdentityManager,
     val delegate: SessionEventsDelegate,
-    val sessionEventsManager: SessionEventsManager,
+    val sessionEventsManager: SessionEventsManager
+) {
+    val pendingTriggerSessionIds: MutableMap<String, String?> = mutableMapOf()
 
-    ) {
-    val pendingTriggerSessions: MutableMap<String, TriggerSession> = mutableMapOf()
-    var activeTriggerSession: TriggerSession? = null
-    var observerCancellables: List<Any> = listOf()
+    /**
+     * The active trigger session tuple in format (sessionId, eventName)
+     */
+    var activeTriggerSession: Pair<String, String>? = null
+
     var configListener: Any? = null
     // TODO: Re-enable
 //    var transactionCount: TriggerSession.Transaction.Count? = null
@@ -59,85 +67,57 @@ class TriggerSessionManager(
         // implementation
     }
 
-    fun createSessions(from: Config) {
-        // implementation
+    suspend fun createSessions(config: Config) {
+        // Loop through triggers and create a session ID for each.
+        for (trigger in config.triggers) {
+            pendingTriggerSessionIds[trigger.eventName] = UUID.randomUUID().toString()
+        }
     }
 
-    fun activateSession(
-        forPresentationInfo: PresentationInfo,
-        on: Activity? = null,
-        paywall: Paywall? = null,
+    suspend fun activateSession(
+        presentationInfo: PresentationInfo,
         triggerResult: InternalTriggerResult? = null,
-        trackEvent: (suspend (Trackable) -> TrackingResult)? = null
-    ) {
-        // implementation
+    ): String? {
+        val eventName = presentationInfo.eventName ?: return null
+
+        val sessionId = pendingTriggerSessionIds[eventName] ?: return null
+
+        val outcome = TriggerSessionManagerLogic.outcome(
+            presentationInfo = presentationInfo,
+            triggerResult = triggerResult?.toPublicType()
+        ) ?: return null
+
+        activeTriggerSession = Pair(sessionId, eventName)
+        pendingTriggerSessionIds[eventName] = null
+
+        triggerResult?.let {
+            val trackedEvent = InternalSuperwallEvent.TriggerFire(
+                triggerResult = it,
+                triggerName = eventName,
+                sessionEventsManager = sessionEventsManager
+            )
+            Superwall.instance.track(trackedEvent)
+        }
+
+        when (outcome) {
+            TriggerSession.PresentationOutcome.HOLDOUT,
+            TriggerSession.PresentationOutcome.NO_RULE_MATCH -> {
+                endSession()
+            }
+            TriggerSession.PresentationOutcome.PAYWALL -> {}
+        }
+
+        return sessionId
     }
 
     fun endSession() {
-        // implementation
-    }
+        val currentTriggerSession = activeTriggerSession ?: return
 
-    fun enqueueCurrentTriggerSession() {
-        // implementation
-    }
+        activeTriggerSession = currentTriggerSession
 
-    fun enqueuePendingTriggerSessions() {
-        // implementation
-    }
+        // Recreate a pending trigger session
+        pendingTriggerSessionIds[currentTriggerSession.second] = UUID.randomUUID().toString()
 
-    fun updateAppSession(to: AppSession) {
-        // implementation
-    }
-
-    fun trackPaywallOpen() {
-        // implementation
-    }
-
-    fun trackPaywallClose() {
-        // implementation
-    }
-
-    fun trackWebviewLoad(forPaywallId: String, state: LoadState) {
-        // implementation
-    }
-
-    fun trackPaywallResponseLoad(forPaywallId: String?, state: LoadState) {
-        // implementation
-    }
-
-    fun trackProductsLoad(forPaywallId: String, state: LoadState) {
-        // implementation
-    }
-
-    fun trackBeginTransaction(of: StoreProduct) {
-        // implementation
-    }
-
-    fun trackTransactionError() {
-        // implementation
-    }
-
-    fun trackTransactionAbandon() {
-        // implementation
-    }
-
-    fun trackTransactionRestoration(withId: String?, product: StoreProduct?) {
-        // implementation
-    }
-
-    fun trackPendingTransaction() {
-        // implementation
-    }
-
-    fun trackTransactionSucceeded(
-        withId: String?,
-        forProduct: StoreProduct,
-        isFreeTrialAvailable: Boolean
-    ) {
-        // implementation
-    }
-
-    fun trackTransactionDeferred(withId: String?, forProduct: StoreProduct) {
-        // implementation
+        activeTriggerSession = null
     }
 }

--- a/superwall/src/main/java/com/superwall/sdk/analytics/trigger_session/TriggerSessionManagerLogic.kt
+++ b/superwall/src/main/java/com/superwall/sdk/analytics/trigger_session/TriggerSessionManagerLogic.kt
@@ -1,0 +1,44 @@
+package com.superwall.sdk.analytics.trigger_session
+
+import android.view.View
+import com.superwall.sdk.analytics.model.TriggerSession
+import com.superwall.sdk.models.paywall.Paywall
+import com.superwall.sdk.models.triggers.TriggerResult
+import com.superwall.sdk.paywall.presentation.internal.request.PresentationInfo
+
+class TriggerSessionManagerLogic {
+    companion object {
+        fun outcome(
+            presentationInfo: PresentationInfo,
+            triggerResult: TriggerResult?
+        ): TriggerSession.PresentationOutcome? {
+            when (presentationInfo) {
+                is PresentationInfo.ImplicitTrigger,
+                is PresentationInfo.ExplicitTrigger -> {
+                    triggerResult ?: return null
+
+                    when (triggerResult) {
+                        is TriggerResult.Error,
+                        is TriggerResult.EventNotFound -> return null
+
+                        is TriggerResult.Holdout -> {
+                            return TriggerSession.PresentationOutcome.HOLDOUT
+                        }
+
+                        is TriggerResult.NoRuleMatch -> {
+                            return TriggerSession.PresentationOutcome.NO_RULE_MATCH
+                        }
+
+                        is TriggerResult.Paywall -> {
+                            return TriggerSession.PresentationOutcome.PAYWALL
+                        }
+                    }
+                }
+
+                is PresentationInfo.FromIdentifier -> {
+                    return TriggerSession.PresentationOutcome.PAYWALL
+                }
+            }
+        }
+    }
+}

--- a/superwall/src/main/java/com/superwall/sdk/config/ConfigManager.kt
+++ b/superwall/src/main/java/com/superwall/sdk/config/ConfigManager.kt
@@ -148,7 +148,7 @@ open class ConfigManager(
                 if (options.paywalls.shouldPreload) {
                     CoroutineScope(Dispatchers.IO).launch { preloadAllPaywalls() }
                 }
-            } catch (e: Exception) {
+            } catch (e: Throwable) {
                 Logger.debug(
                     logLevel = LogLevel.error,
                     scope = LogScope.configManager,

--- a/superwall/src/main/java/com/superwall/sdk/delegate/PurchaseResult.kt
+++ b/superwall/src/main/java/com/superwall/sdk/delegate/PurchaseResult.kt
@@ -1,9 +1,9 @@
 package com.superwall.sdk.delegate
 
-import com.superwall.sdk.store.abstractions.transactions.StoreTransactionType
+import com.android.billingclient.api.Purchase
 
 sealed class InternalPurchaseResult {
-    data class Purchased(val storeTransaction: StoreTransactionType?) : InternalPurchaseResult()
+    data class Purchased(val purchase: Purchase) : InternalPurchaseResult()
     object Restored : InternalPurchaseResult()
     object Cancelled : InternalPurchaseResult()
     object Pending : InternalPurchaseResult()

--- a/superwall/src/main/java/com/superwall/sdk/dependencies/DependencyContainer.kt
+++ b/superwall/src/main/java/com/superwall/sdk/dependencies/DependencyContainer.kt
@@ -334,7 +334,6 @@ class DependencyContainer(
             sessionEventsManager = sessionEventsManager,
             storage = storage,
             configManager = configManager,
-            appSessionManager = appSessionManager,
             identityManager = identityManager
         )
     }
@@ -411,7 +410,7 @@ class DependencyContainer(
     }
 
     override suspend fun makeStoreTransaction(transaction: Purchase): StoreTransaction {
-        val triggerSessionId =  sessionEventsManager.triggerSession.activeTriggerSession?.first
+        val triggerSessionId =  sessionEventsManager.triggerSession.activeTriggerSession?.sessionId
         return StoreTransaction(
             GoogleBillingPurchaseTransaction(
                 transaction = transaction,

--- a/superwall/src/main/java/com/superwall/sdk/dependencies/DependencyContainer.kt
+++ b/superwall/src/main/java/com/superwall/sdk/dependencies/DependencyContainer.kt
@@ -53,6 +53,7 @@ import com.superwall.sdk.storage.Storage
 import com.superwall.sdk.store.InternalPurchaseController
 import com.superwall.sdk.store.StoreKitManager
 import com.superwall.sdk.store.abstractions.transactions.GoogleBillingPurchaseTransaction
+import com.superwall.sdk.store.abstractions.transactions.StoreTransaction
 import com.superwall.sdk.store.abstractions.transactions.StoreTransactionType
 import com.superwall.sdk.store.transactions.GoogleBillingTransactionVerifier
 import com.superwall.sdk.store.transactions.TransactionManager
@@ -181,7 +182,6 @@ class DependencyContainer(
             "Authorization" to auth,
             "X-Platform" to "Android",
             "X-Platform-Environment" to "SDK",
-            // TODO: Add app user id: https://linear.app/superwall/issue/SW-2365/[android]-add-appuserid
             "X-App-User-ID" to (identityManager.getAppUserId() ?: ""),
             "X-Alias-ID" to identityManager.getAliasId(),
             "X-URL-Scheme" to deviceHelper.urlScheme,
@@ -256,7 +256,6 @@ class DependencyContainer(
     override fun makeCache(): PaywallViewControllerCache {
         return PaywallViewControllerCache(deviceHelper.locale)
     }
-
 
     override fun makeDeviceInfo(): DeviceInfo {
         return DeviceInfo(
@@ -407,9 +406,15 @@ class DependencyContainer(
         return variables
     }
 
-    override suspend fun makeStoreTransaction(transaction: Purchase): StoreTransactionType {
-        return GoogleBillingPurchaseTransaction(
-            transaction = transaction,
+    override suspend fun makeStoreTransaction(transaction: Purchase): StoreTransaction {
+        val triggerSessionId =  sessionEventsManager.triggerSession.activeTriggerSession?.first
+        return StoreTransaction(
+            GoogleBillingPurchaseTransaction(
+                transaction = transaction,
+            ),
+            configRequestId = configManager.config?.requestId ?: "",
+            appSessionId = appSessionManager.appSession.id,
+            triggerSessionId = triggerSessionId
         )
     }
 

--- a/superwall/src/main/java/com/superwall/sdk/dependencies/DependencyContainer.kt
+++ b/superwall/src/main/java/com/superwall/sdk/dependencies/DependencyContainer.kt
@@ -171,7 +171,7 @@ class DependencyContainer(
 
         // Calling this just to initialise the trigger session manager so it can start listening
         // to config.
-        makeTriggerSessionManager()
+        sessionEventsManager.triggerSession
     }
 
 
@@ -410,7 +410,7 @@ class DependencyContainer(
     }
 
     override suspend fun makeStoreTransaction(transaction: Purchase): StoreTransaction {
-        val triggerSessionId =  sessionEventsManager.triggerSession.activeTriggerSession?.sessionId
+        val triggerSessionId =  sessionEventsManager.triggerSession.getActiveTriggerSession()?.sessionId
         return StoreTransaction(
             GoogleBillingPurchaseTransaction(
                 transaction = transaction,

--- a/superwall/src/main/java/com/superwall/sdk/dependencies/DependencyContainer.kt
+++ b/superwall/src/main/java/com/superwall/sdk/dependencies/DependencyContainer.kt
@@ -168,6 +168,10 @@ class DependencyContainer(
             activityLifecycleTracker,
             factory = this
         )
+
+        // Calling this just to initialise the trigger session manager so it can start listening
+        // to config.
+        makeTriggerSessionManager()
     }
 
 

--- a/superwall/src/main/java/com/superwall/sdk/dependencies/FactoryProtocols.kt
+++ b/superwall/src/main/java/com/superwall/sdk/dependencies/FactoryProtocols.kt
@@ -26,6 +26,7 @@ import com.superwall.sdk.paywall.vc.PaywallViewController
 import com.superwall.sdk.paywall.vc.delegate.PaywallViewControllerDelegateAdapter
 import com.superwall.sdk.paywall.vc.web_view.templating.models.JsonVariables
 import com.superwall.sdk.storage.Storage
+import com.superwall.sdk.store.abstractions.transactions.StoreTransaction
 import com.superwall.sdk.store.abstractions.transactions.StoreTransactionType
 import com.superwall.sdk.store.transactions.GoogleBillingTransactionVerifier
 import kotlinx.coroutines.flow.StateFlow
@@ -173,7 +174,7 @@ interface ConfigManagerFactory {
 //}
 
 interface StoreTransactionFactory {
-    suspend fun makeStoreTransaction(transaction: Purchase): StoreTransactionType
+    suspend fun makeStoreTransaction(transaction: Purchase): StoreTransaction
 }
 
 interface OptionsFactory {

--- a/superwall/src/main/java/com/superwall/sdk/models/paywall/Paywall.kt
+++ b/superwall/src/main/java/com/superwall/sdk/models/paywall/Paywall.kt
@@ -76,6 +76,9 @@ data class Paywall(
     var experiment: Experiment? = null,
 
     @kotlinx.serialization.Transient()
+    var triggerSessionId: String? = null,
+
+    @kotlinx.serialization.Transient()
     var closeReason: PaywallCloseReason = PaywallCloseReason.None,
 
     /**
@@ -144,6 +147,7 @@ data class Paywall(
             productsLoadFailTime = productsLoadingInfo.failAt,
             productsLoadCompleteTime = productsLoadingInfo.endAt,
             experiment = experiment,
+            triggerSessionId = triggerSessionId,
             paywalljsVersion = paywalljsVersion,
             isFreeTrialAvailable = isFreeTrialAvailable,
             factory = factory,

--- a/superwall/src/main/java/com/superwall/sdk/network/Network.kt
+++ b/superwall/src/main/java/com/superwall/sdk/network/Network.kt
@@ -152,9 +152,9 @@ open class Network(
         }
     }
 
-    open suspend fun getAssignments(): List<Assignment> {
+    suspend fun getAssignments(): List<Assignment> {
         return try {
-            val result = urlSession.request<ConfirmedAssignmentResponse>(
+            val result = urlSession.request(
                 Endpoint.assignments(factory = factory)
             )
             result.assignments

--- a/superwall/src/main/java/com/superwall/sdk/paywall/presentation/PaywallInfo.kt
+++ b/superwall/src/main/java/com/superwall/sdk/paywall/presentation/PaywallInfo.kt
@@ -24,6 +24,7 @@ data class PaywallInfo(
     @Serializable(with = URLSerializer::class)
     val url: URL,
     val experiment: Experiment?,
+    val triggerSessionId: String?,
     val products: List<Product>,
     val productIds: List<String>,
     val presentedByEventWithName: String?,
@@ -67,6 +68,7 @@ data class PaywallInfo(
         productsLoadFailTime: Date?,
         productsLoadCompleteTime: Date?,
         experiment: Experiment? = null,
+        triggerSessionId: String? = null,
         paywalljsVersion: String? = null,
         isFreeTrialAvailable: Boolean,
         presentationSourceType: String? = null,
@@ -83,6 +85,7 @@ data class PaywallInfo(
         presentedByEventAt = eventData?.createdAt?.toString(),
         presentedByEventWithId = eventData?.id?.lowercase(),
         experiment = experiment,
+        triggerSessionId = triggerSessionId,
         paywalljsVersion = paywalljsVersion,
         products = products,
         productIds = products.map { it.id },
@@ -142,20 +145,13 @@ data class PaywallInfo(
             "paywall_products_load_complete_time" to productsLoadCompleteTime,
             "paywall_products_load_fail_time" to productsLoadFailTime,
             "paywall_products_load_duration" to productsLoadDuration,
+            "trigger_session_id" to triggerSessionId,
+            "experiment_id" to experiment?.id,
+            "variant_id" to experiment?.variant?.id
         )
         params.values.removeAll { it == null }
         val filteredParams = params as MutableMap<String, Any>
         output.putAll(filteredParams)
-
-        // TODO: Re-enable this
-//        val triggerSessionManager = factory.getTriggerSessionManager()
-//        val triggerSession = triggerSessionManager.activeTriggerSession
-//
-//        if (triggerSession?.paywall?.databaseId == this.databaseId) {
-//            output["trigger_session_id"] = triggerSession.id
-//            output["experiment_id"] = triggerSession.trigger.experiment?.id
-//            output["variant_id"] = triggerSession.trigger.experiment?.variant?.id
-//        }
 
         val loadingVars = mutableMapOf<String, Any>()
         for (key in output.keys) {

--- a/superwall/src/main/java/com/superwall/sdk/paywall/presentation/internal/operators/GetExperiment.kt
+++ b/superwall/src/main/java/com/superwall/sdk/paywall/presentation/internal/operators/GetExperiment.kt
@@ -82,8 +82,7 @@ private suspend fun Superwall.activateSession(
     }
     val sessionEventsManager = dependencyContainer.sessionEventsManager
     sessionEventsManager?.triggerSession?.activateSession(
-        forPresentationInfo = request.presentationInfo,
-        on = request.presenter,
+        presentationInfo = request.presentationInfo,
         triggerResult = rulesOutcome.triggerResult
     )
 }

--- a/superwall/src/main/java/com/superwall/sdk/paywall/presentation/internal/operators/GetPresenter.kt
+++ b/superwall/src/main/java/com/superwall/sdk/paywall/presentation/internal/operators/GetPresenter.kt
@@ -46,11 +46,11 @@ suspend fun Superwall.getPresenterIfNecessary(
 
     when (request.flags.type) {
         is PresentationRequestType.GetPaywall -> {
-            activateSession(
+            val sessionId = activateSession(
                 request = request,
-                paywall = paywallViewController.paywall,
                 triggerResult = rulesOutcome.triggerResult
             )
+            paywallViewController.paywall.triggerSessionId = sessionId
             return null
         }
 
@@ -60,26 +60,23 @@ suspend fun Superwall.getPresenterIfNecessary(
         else -> Unit
     }
 
-    activateSession(
+    val sessionId = activateSession(
         request = request,
-        paywall = paywallViewController.paywall,
         triggerResult = rulesOutcome.triggerResult
     )
+    paywallViewController.paywall.triggerSessionId = sessionId
 
     return dependencyContainer.activityLifecycleTracker.getCurrentActivity()
 }
 
 
-private fun Superwall.activateSession(
+private suspend fun Superwall.activateSession(
     request: PresentationRequest,
-    paywall: Paywall,
     triggerResult: InternalTriggerResult
-) {
+): String? {
     val sessionEventsManager = dependencyContainer.sessionEventsManager
-    sessionEventsManager?.triggerSession?.activateSession(
+    return sessionEventsManager?.triggerSession?.activateSession(
         request.presentationInfo,
-        request.presenter,
-        paywall,
         triggerResult
     )
 }

--- a/superwall/src/main/java/com/superwall/sdk/paywall/vc/PaywallViewController.kt
+++ b/superwall/src/main/java/com/superwall/sdk/paywall/vc/PaywallViewController.kt
@@ -434,7 +434,6 @@ class PaywallViewController(
         Superwall.instance.dependencyContainer.delegateAdapter.didPresentPaywall(info)
 
         CoroutineScope(Dispatchers.IO).launch {
-            print("*** TRACK OPEN*** ")
             trackOpen()
         }
 
@@ -624,7 +623,6 @@ class PaywallViewController(
 
     fun loadWebView() {
         val url = paywall.url
-    println("*** HEY!")
         if (paywall.webviewLoadingInfo.startAt == null) {
             paywall.webviewLoadingInfo.startAt = Date()
         }

--- a/superwall/src/main/java/com/superwall/sdk/paywall/vc/PaywallViewController.kt
+++ b/superwall/src/main/java/com/superwall/sdk/paywall/vc/PaywallViewController.kt
@@ -453,8 +453,6 @@ class PaywallViewController(
     private var initialOrientation: Int? = null
 
     private suspend fun trackOpen() {
-        val triggerSessionManager = factory.getTriggerSessionManager()
-        triggerSessionManager.trackPaywallOpen()
         storage.trackPaywallOpen()
         val trackedEvent = InternalSuperwallEvent.PaywallOpen(info)
         Superwall.instance.track(trackedEvent)
@@ -468,7 +466,7 @@ class PaywallViewController(
             surveyPresentationResult
         )
         Superwall.instance.track(trackedEvent)
-        triggerSessionManager.trackPaywallClose()
+        triggerSessionManager.endSession()
     }
 
     override fun eventDidOccur(paywallEvent: PaywallWebEvent) {
@@ -637,12 +635,6 @@ class PaywallViewController(
                 paywallInfo = this@PaywallViewController.info
             )
             Superwall.instance.track(trackedEvent)
-
-            val triggerSessionManager = factory.getTriggerSessionManager()
-            triggerSessionManager.trackWebviewLoad(
-                forPaywallId = info.databaseId,
-                state = LoadState.START
-            )
         }
 
         if (paywall.onDeviceCache is OnDeviceCaching.Enabled) {

--- a/superwall/src/main/java/com/superwall/sdk/paywall/vc/web_view/SWWebView.kt
+++ b/superwall/src/main/java/com/superwall/sdk/paywall/vc/web_view/SWWebView.kt
@@ -133,11 +133,6 @@ class SWWebView(
 
         val paywallInfo = delegate?.info ?: return
 
-        sessionEventsManager.triggerSession.trackWebviewLoad(
-            forPaywallId = paywallInfo.databaseId,
-            state = LoadState.FAIL
-        )
-
         val trackedEvent = InternalSuperwallEvent.PaywallWebviewLoad(
             state = InternalSuperwallEvent.PaywallWebviewLoad.State.Fail(),
             paywallInfo = paywallInfo

--- a/superwall/src/main/java/com/superwall/sdk/paywall/vc/web_view/messaging/PaywallMessageHandler.kt
+++ b/superwall/src/main/java/com/superwall/sdk/paywall/vc/web_view/messaging/PaywallMessageHandler.kt
@@ -149,11 +149,6 @@ class PaywallMessageHandler(
                     paywallInfo = paywallInfo
                 )
                 Superwall.instance.track(trackedEvent)
-
-                sessionEventsManager.triggerSession.trackWebviewLoad(
-                    forPaywallId = paywallInfo.databaseId,
-                    state = LoadState.END
-                )
             }
         }
 

--- a/superwall/src/main/java/com/superwall/sdk/store/abstractions/transactions/StoreTransaction.kt
+++ b/superwall/src/main/java/com/superwall/sdk/store/abstractions/transactions/StoreTransaction.kt
@@ -1,5 +1,7 @@
 package com.superwall.sdk.store.abstractions.transactions
 
+import com.superwall.sdk.models.serialization.DateSerializer
+import com.superwall.sdk.models.serialization.UUIDSerializer
 import kotlinx.serialization.Serializable
 import java.util.*
 
@@ -10,28 +12,26 @@ class StoreTransaction(
     val appSessionId: String,
     val triggerSessionId: String?
 ) : StoreTransactionType {
-
-    private val id = UUID.randomUUID().toString()
+    val id = UUID.randomUUID().toString()
 
     override val transactionDate: Date? get() = transaction.transactionDate
     override val originalTransactionIdentifier: String get() = transaction.originalTransactionIdentifier
     override val state: StoreTransactionState get() = transaction.state
     override val storeTransactionId: String? get() = transaction.storeTransactionId
     override val payment: StorePayment? get() = transaction.payment
+    @Serializable(with = DateSerializer::class)
     override val originalTransactionDate: Date? get() = transaction.originalTransactionDate
     override val webOrderLineItemID: String? get() = transaction.webOrderLineItemID
     override val appBundleId: String? get() = transaction.appBundleId
     override val subscriptionGroupId: String? get() = transaction.subscriptionGroupId
     override val isUpgraded: Boolean? get() = transaction.isUpgraded
+    @Serializable(with = DateSerializer::class)
     override val expirationDate: Date? get() = transaction.expirationDate
     override val offerId: String? get() = transaction.offerId
+    @Serializable(with = DateSerializer::class)
     override val revocationDate: Date? get() = transaction.revocationDate
+    @Serializable(with = UUIDSerializer::class)
     override val appAccountToken: UUID? get() = transaction.appAccountToken
-
-    // You can define SK1Transaction and SK2Transaction conversion methods here
-    // based on the Android billing library.
-
-
 }
 
 

--- a/superwall/src/main/java/com/superwall/sdk/store/abstractions/transactions/StoreTransaction.kt
+++ b/superwall/src/main/java/com/superwall/sdk/store/abstractions/transactions/StoreTransaction.kt
@@ -2,14 +2,18 @@ package com.superwall.sdk.store.abstractions.transactions
 
 import com.superwall.sdk.models.serialization.DateSerializer
 import com.superwall.sdk.models.serialization.UUIDSerializer
+import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import java.util.*
 
 @Serializable
 class StoreTransaction(
-    private val transaction: StoreTransactionType,
+    private val transaction: GoogleBillingPurchaseTransaction,
+    @SerialName("config_request_id")
     val configRequestId: String,
+    @SerialName("app_session_id")
     val appSessionId: String,
+    @SerialName("trigger_session_id")
     val triggerSessionId: String?
 ) : StoreTransactionType {
     val id = UUID.randomUUID().toString()

--- a/superwall/src/main/java/com/superwall/sdk/store/transactions/TransactionManager.kt
+++ b/superwall/src/main/java/com/superwall/sdk/store/transactions/TransactionManager.kt
@@ -23,7 +23,7 @@ import com.superwall.sdk.paywall.vc.PaywallViewController
 import com.superwall.sdk.paywall.vc.delegate.PaywallLoadingState
 import com.superwall.sdk.store.StoreKitManager
 import com.superwall.sdk.store.abstractions.product.StoreProduct
-import com.superwall.sdk.store.abstractions.transactions.StoreTransactionType
+import com.superwall.sdk.store.abstractions.transactions.StoreTransaction
 import kotlinx.coroutines.*
 
 class TransactionManager(
@@ -285,7 +285,7 @@ class TransactionManager(
 
     // ... and so on for the other methods ...
     private suspend fun trackTransactionDidSucceed(
-        transaction: StoreTransactionType?,
+        transaction: StoreTransaction?,
         product: StoreProduct
     ) {
         val paywallViewController = lastPaywallViewController ?: return


### PR DESCRIPTION
- `TriggerSessionManager` now only generates triggerSessionIds and has a mapping of event to sessionId. The active trigger session contains the sessionId and the event associated with that.
- Returns `StoreTransaction` rather than `StoreTransactionType`.
- `Paywall`/`PaywallInfo` now contains the `triggerSessionId` and experiment/variant Id