### PR TITLE
Subscription period strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The changelog for `Superwall`. Also see the [releases](https://github.com/superwall-me/Superwall-Android/releases) on GitHub.
 
+## 1.0.0-alpha.24
+
+### Fixes
+
+- Fixes an issue that could cause "n/a" to be displayed on a paywall in place of the proper subscription period string.
+
 ## 1.0.0-alpha.23
 
 ### Fixes

--- a/superwall/src/main/java/com/superwall/sdk/store/abstractions/product/StoreProduct.kt
+++ b/superwall/src/main/java/com/superwall/sdk/store/abstractions/product/StoreProduct.kt
@@ -52,12 +52,29 @@ class StoreProduct(
     override val subscriptionPeriod: SubscriptionPeriod?
         get() {
             return try {
-                SubscriptionPeriod.from(rawStoreProduct.skuDetails.freeTrialPeriod, Currency.getInstance(rawStoreProduct.skuDetails.priceCurrencyCode))
+                SubscriptionPeriod.from(
+                    rawStoreProduct.skuDetails.subscriptionPeriod,
+                    Currency.getInstance(rawStoreProduct.skuDetails.priceCurrencyCode)
+                )
             } catch (e: Exception) {
                 null
             }
         }
 
+    /**
+     * The trial subscription period of the product.
+     */
+    val trialSubscriptionPeriod: SubscriptionPeriod?
+        get() {
+            return try {
+                SubscriptionPeriod.from(
+                    rawStoreProduct.skuDetails.freeTrialPeriod,
+                    Currency.getInstance(rawStoreProduct.skuDetails.priceCurrencyCode)
+                )
+            } catch (e: Exception) {
+                null
+            }
+        }
 
     override val localizedPrice: String
         get() = rawStoreProduct.skuDetails.price
@@ -108,21 +125,6 @@ class StoreProduct(
 
     override val yearlyPrice: String
         get() = subscriptionPeriod?.yearlyPrice(price) ?: "n/a"
-
-    /**
-     * The trial subscription period of the product.
-     */
-    val trialSubscriptionPeriod: SubscriptionPeriod?
-        get() {
-            return try {
-                SubscriptionPeriod.from(
-                    rawStoreProduct.skuDetails.freeTrialPeriod,
-                    Currency.getInstance(rawStoreProduct.skuDetails.priceCurrencyCode)
-                )
-            } catch (e: Exception) {
-                null
-            }
-        }
 
 
     override val hasFreeTrial: Boolean


### PR DESCRIPTION
Fixes an issue that could cause "n/a" to be displayed on a paywall in place of the proper subscription period string.