### PR TITLE
v1.0.0-alpha.28

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 The changelog for `Superwall`. Also see the [releases](https://github.com/superwall-me/Superwall-Android/releases) on GitHub.
 
+## 1.0.0-alpha.28
+
+### Fixes
+
+- SW-2615: Fixes crash on Android versions <8 when accessing the Android 8+ only class Period.
+- SW-2616: Fixes crash where the `PaywallViewController` was sometimes being added to a new parent view before
+being removed from it's existing parent view.
+
 ## 1.0.0-alpha.27
 
 ### Breaking Changes

--- a/superwall/build.gradle.kts
+++ b/superwall/build.gradle.kts
@@ -19,7 +19,7 @@ plugins {
     id("maven-publish")
 }
 
-version = "1.0.0-alpha.27"
+version = "1.0.0-alpha.28"
 
 android {
     compileSdk = 33

--- a/superwall/build.gradle.kts
+++ b/superwall/build.gradle.kts
@@ -133,6 +133,7 @@ dependencies {
     implementation("androidx.room:room-ktx:2.5.2")
     kapt("androidx.room:room-compiler:2.5.2")
 
+    implementation("org.threeten:threetenbp:1.6.8")
     // Billing
     implementation(libs.billing)
 

--- a/superwall/src/main/java/com/superwall/sdk/Superwall.kt
+++ b/superwall/src/main/java/com/superwall/sdk/Superwall.kt
@@ -118,7 +118,7 @@ class Superwall(
     companion object {
         var initialized: Boolean = false
 
-        val _hasInitialized = MutableStateFlow<Boolean>(false)
+        private val _hasInitialized = MutableStateFlow<Boolean>(false)
 
         // A flow that emits just once only when `hasInitialized` is non-`nil`.
         val hasInitialized: Flow<Boolean> = _hasInitialized

--- a/superwall/src/main/java/com/superwall/sdk/contrib/threeteen/AmountFormats.kt
+++ b/superwall/src/main/java/com/superwall/sdk/contrib/threeteen/AmountFormats.kt
@@ -1,7 +1,7 @@
 package com.superwall.sdk.contrib.threeteen
 
+import org.threeten.bp.Period
 import java.time.Duration
-import java.time.Period
 import java.time.format.DateTimeParseException
 import java.util.*
 import java.util.function.Function

--- a/superwall/src/main/java/com/superwall/sdk/paywall/vc/PaywallViewController.kt
+++ b/superwall/src/main/java/com/superwall/sdk/paywall/vc/PaywallViewController.kt
@@ -810,6 +810,8 @@ class SuperwallPaywallActivity : AppCompatActivity() {
             return
         }
 
+        (view.parent as? ViewGroup)?.removeView(view)
+
         if (view is ActivityEncapsulatable) {
             view.encapsulatingActivity = this
         }

--- a/superwall/src/main/java/com/superwall/sdk/store/abstractions/product/SubscriptionPeriod.kt
+++ b/superwall/src/main/java/com/superwall/sdk/store/abstractions/product/SubscriptionPeriod.kt
@@ -1,11 +1,9 @@
 package com.superwall.sdk.store.abstractions.product
 
+import org.threeten.bp.Period
 import java.math.BigDecimal
 import java.math.RoundingMode
-import java.text.DecimalFormat
-import java.time.Period
-import java.time.temporal.ChronoUnit
-import java.util.*
+
 
 data class SubscriptionPeriod(val value: Int, val unit: Unit) {
     enum class Unit {


### PR DESCRIPTION
### Fixes

- SW-2615: Fixes crash on Android versions <8 when accessing the Android 8+ only class Period. Here we've used a backwards compatible version of Period by a third party.
- SW-2616: Fixes crash where the `PaywallViewController` was sometimes being added to a new parent view before
being removed from it's existing parent view.