### PR TITLE
v1.0.0-alpha.29

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 The changelog for `Superwall`. Also see the [releases](https://github.com/superwall-me/Superwall-Android/releases) on GitHub.
 
+## 1.0.0-alpha.29
+
+### Fixes
+
+- SW-2631: Fixes issue where paywalls weren't showing if the products within them had a base plan or
+offer ID set.
+
 ## 1.0.0-alpha.28
 
 ### Fixes

--- a/app/src/main/java/com/superwall/superapp/test/UITestActivity.kt
+++ b/app/src/main/java/com/superwall/superapp/test/UITestActivity.kt
@@ -133,6 +133,7 @@ fun UITestTable() {
         UITestHandler.testAndroid18Info to { CoroutineScope(Dispatchers.IO).launch { UITestHandler.testAndroid18() } },
         UITestHandler.testAndroid19Info to { CoroutineScope(Dispatchers.IO).launch { UITestHandler.testAndroid19() } },
         UITestHandler.testAndroid20Info to { CoroutineScope(Dispatchers.IO).launch { UITestHandler.testAndroid20() } },
+        UITestHandler.testAndroid21Info to { CoroutineScope(Dispatchers.IO).launch { UITestHandler.testAndroid21() } },
     )
 
     LazyColumn {

--- a/app/src/main/java/com/superwall/superapp/test/UITestHandler.kt
+++ b/app/src/main/java/com/superwall/superapp/test/UITestHandler.kt
@@ -1405,5 +1405,15 @@ class UITestHandler {
 
             Superwall.instance.register(event = "non_recurring_product")
         }
+
+        var testAndroid21Info = UITestInfo(
+            21,
+            "Tap launch button. Paywall should display. Tests that paywalls with products " +
+                    "that have base plans and offerIds works.",
+            testCaseType = TestCaseType.Android
+        )
+        suspend fun testAndroid21() {
+            Superwall.instance.register(event = "subs_baseplan_offer_with_free_trial")
+        }
     }
 }

--- a/superwall/build.gradle.kts
+++ b/superwall/build.gradle.kts
@@ -19,7 +19,7 @@ plugins {
     id("maven-publish")
 }
 
-version = "1.0.0-alpha.28"
+version = "1.0.0-alpha.29"
 
 android {
     compileSdk = 33


### PR DESCRIPTION
### Fixes

- SW-2631: Fixes issue where paywalls weren't showing if the products within them had a base plan or
offer ID set. When products had a base plan/offer set, it would get stuck in a loading state and the paywall wouldn't show. This was due to a mix up between subscriptionId and the fullId of the product (which contains both the subscriptionId and the base plan id/offer Id separated with colons).
- Increments version to alpha 29.