### PR TITLE
Adds Restored to PurchaseResult: Closes SW-2638

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ The changelog for `Superwall`. Also see the [releases](https://github.com/superw
 
 ## 1.0.0-alpha.31
 
+### Enhancements
+
+- Adds `Restored` to `PurchaseResult`.
+
 ### Fixes
 
 - SW-2635: Fixes crash that sometimes occurred if an app was trying to get Superwall's paywall 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The changelog for `Superwall`. Also see the [releases](https://github.com/superw
 
 ### Enhancements
 
-- Adds `Restored` to `PurchaseResult`.
+- SW-2638: Adds `Restored` to `PurchaseResult`.
 
 ### Fixes
 

--- a/superwall/src/main/java/com/superwall/sdk/Superwall.kt
+++ b/superwall/src/main/java/com/superwall/sdk/Superwall.kt
@@ -405,7 +405,7 @@ class Superwall(
                     }
                 }
                 is InitiateRestore -> {
-                    dependencyContainer.storeKitManager.purchaseController.tryToRestore(paywallViewController)
+                    dependencyContainer.transactionManager.tryToRestore(paywallViewController)
                 }
                 is OpenedURL -> {
                     dependencyContainer.delegateAdapter.paywallWillOpenURL(url = paywallEvent.url)

--- a/superwall/src/main/java/com/superwall/sdk/analytics/internal/trackable/TrackableSuperwallEvent.kt
+++ b/superwall/src/main/java/com/superwall/sdk/analytics/internal/trackable/TrackableSuperwallEvent.kt
@@ -20,6 +20,7 @@ import com.superwall.sdk.paywall.vc.Survey.SurveyPresentationResult
 import com.superwall.sdk.store.abstractions.product.StoreProduct
 import com.superwall.sdk.store.abstractions.transactions.StoreTransaction
 import com.superwall.sdk.store.abstractions.transactions.StoreTransactionType
+import com.superwall.sdk.store.transactions.RestoreType
 import com.superwall.sdk.store.transactions.TransactionError
 
 
@@ -372,8 +373,7 @@ sealed class InternalSuperwallEvent(override val superwallEvent: SuperwallEvent)
             class Abandon(val product: StoreProduct) : State()
             class Complete(val product: StoreProduct, val transaction: StoreTransactionType?) :
                 State()
-
-            class Restore : State()
+            class Restore(val restoreType: RestoreType) : State()
             class Timeout : State()
         }
 
@@ -401,7 +401,10 @@ sealed class InternalSuperwallEvent(override val superwallEvent: SuperwallEvent)
                     product = state.product,
                     paywallInfo = paywallInfo
                 )
-                is State.Restore -> SuperwallEvent.TransactionRestore(paywallInfo = paywallInfo)
+                is State.Restore -> SuperwallEvent.TransactionRestore(
+                    restoreType = state.restoreType,
+                    paywallInfo = paywallInfo
+                )
                 is State.Timeout -> SuperwallEvent.TransactionTimeout(paywallInfo = paywallInfo)
             }
         override val rawName: String

--- a/superwall/src/main/java/com/superwall/sdk/analytics/superwall/SuperwallEvent.kt
+++ b/superwall/src/main/java/com/superwall/sdk/analytics/superwall/SuperwallEvent.kt
@@ -9,6 +9,7 @@ import com.superwall.sdk.paywall.presentation.internal.PaywallPresentationReques
 import com.superwall.sdk.paywall.presentation.internal.PaywallPresentationRequestStatusReason
 import com.superwall.sdk.store.abstractions.product.StoreProduct
 import com.superwall.sdk.store.abstractions.transactions.StoreTransactionType
+import com.superwall.sdk.store.transactions.RestoreType
 import com.superwall.sdk.store.transactions.TransactionError
 import java.net.URL
 
@@ -160,7 +161,10 @@ sealed class SuperwallEvent {
     }
 
     /// When the user successfully restores their purchases.
-    data class TransactionRestore(val paywallInfo: PaywallInfo) : SuperwallEvent() {
+    data class TransactionRestore(
+        val restoreType: RestoreType,
+        val paywallInfo: PaywallInfo
+    ) : SuperwallEvent() {
         override val rawName: String
             get() = "transaction_restore"
     }

--- a/superwall/src/main/java/com/superwall/sdk/billing/GoogleBillingWrapper.kt
+++ b/superwall/src/main/java/com/superwall/sdk/billing/GoogleBillingWrapper.kt
@@ -183,7 +183,7 @@ open class GoogleBillingWrapper(open val context: Context, open val mainHandler:
     }
 
 
-    public suspend fun waitForConnectedClient(receivingFunction: BillingClient.() -> Unit) {
+    suspend fun waitForConnectedClient(receivingFunction: BillingClient.() -> Unit) {
         // Call this every time to make sure we're waiting for the client to connect
         startConnectionOnMainThread(0)
         isConnected.first { it }

--- a/superwall/src/main/java/com/superwall/sdk/delegate/PurchaseResult.kt
+++ b/superwall/src/main/java/com/superwall/sdk/delegate/PurchaseResult.kt
@@ -40,6 +40,11 @@ sealed class PurchaseResult {
     class Pending : PurchaseResult()
 
     /**
+     * The product was restored.
+     */
+    class Restored : PurchaseResult()
+
+    /**
      * The purchase failed for a reason other than the user cancelling or the payment pending.
      *
      * Send the `Exception` back to the relevant method to alert the user.

--- a/superwall/src/main/java/com/superwall/sdk/dependencies/DependencyContainer.kt
+++ b/superwall/src/main/java/com/superwall/sdk/dependencies/DependencyContainer.kt
@@ -193,6 +193,7 @@ class DependencyContainer(
 
         transactionManager = TransactionManager(
             storeKitManager = storeKitManager,
+            purchaseController = purchaseController,
             sessionEventsManager,
             activityProvider,
             factory = this

--- a/superwall/src/main/java/com/superwall/sdk/dependencies/FactoryProtocols.kt
+++ b/superwall/src/main/java/com/superwall/sdk/dependencies/FactoryProtocols.kt
@@ -134,7 +134,6 @@ interface ViewControllerFactory {
     fun makeDebugViewController(id: String?): DebugViewController
 }
 
-
 //ViewControllerFactory & CacheFactory & DeviceInfoFactory,
 //interface ViewControllerCacheDevice {
 //    suspend fun makePaywallViewController(

--- a/superwall/src/main/java/com/superwall/sdk/store/products/GooglePlayProductsFetcher.kt
+++ b/superwall/src/main/java/com/superwall/sdk/store/products/GooglePlayProductsFetcher.kt
@@ -87,8 +87,6 @@ open class GooglePlayProductsFetcher(
                 // Check if the result for the current full product ID is already available
                 val result = currentResults[productIds.fullId]
 
-                println("Result for $productId is $result ${Thread.currentThread().name}")
-
                 // If the result is null, process the product ID
                 if (result == null) {
                     val subscriptionId = productIds.subscriptionId
@@ -101,7 +99,7 @@ open class GooglePlayProductsFetcher(
                 }
             }
 
-           // println("!!! Requesting ${subscriptionIdsToLoad.size} products")
+            println("!!! Requesting ${productIdsToLoad.size} products")
 
             // Check if there are any product IDs to load
             if (productIdsToLoad.isNotEmpty()) {
@@ -116,7 +114,7 @@ open class GooglePlayProductsFetcher(
 
                 // Perform the network request to get product details using the subscription id.
                 val networkResult = runBlocking {
-                    val subscriptionIdsToLoad = productIdsToLoad.map { it.subscriptionId }.toList()
+                    val subscriptionIdsToLoad = productIdsToLoad.map { it.subscriptionId }.distinct()
                     queryProductDetails(subscriptionIdsToLoad)
                 }
                 println("!! networkResult: ${networkResult} ${Thread.currentThread().name}")
@@ -230,9 +228,6 @@ open class GooglePlayProductsFetcher(
 
             val subscriptionIdToResult = productDetailsList
                 .flatMap { productDetails ->
-                    if (productDetails.productId == "com.ui_tests.monthly") {
-    println("Hmm")
-                    }
                     productIdsBySubscriptionId[productDetails.productId]?.map { productId ->
                         productId.fullId to Result.Success(
                             RawStoreProduct(

--- a/superwall/src/main/java/com/superwall/sdk/store/transactions/RestoreType.kt
+++ b/superwall/src/main/java/com/superwall/sdk/store/transactions/RestoreType.kt
@@ -1,0 +1,8 @@
+package com.superwall.sdk.store.transactions
+
+import com.superwall.sdk.store.abstractions.transactions.StoreTransaction
+
+sealed class RestoreType {
+    data class ViaPurchase(val transaction: StoreTransaction?) : RestoreType()
+    object ViaRestore : RestoreType()
+}

--- a/superwall/src/main/java/com/superwall/sdk/store/transactions/TransactionManager.kt
+++ b/superwall/src/main/java/com/superwall/sdk/store/transactions/TransactionManager.kt
@@ -9,6 +9,9 @@ import com.superwall.sdk.analytics.internal.track
 import com.superwall.sdk.analytics.internal.trackable.InternalSuperwallEvent
 import com.superwall.sdk.analytics.superwall.SuperwallEventObjc
 import com.superwall.sdk.delegate.PurchaseResult
+import com.superwall.sdk.delegate.RestorationResult
+import com.superwall.sdk.delegate.SubscriptionStatus
+import com.superwall.sdk.delegate.subscription_controller.PurchaseController
 import com.superwall.sdk.dependencies.OptionsFactory
 import com.superwall.sdk.dependencies.StoreTransactionFactory
 import com.superwall.sdk.dependencies.TransactionVerifierFactory
@@ -25,6 +28,7 @@ import kotlinx.coroutines.*
 
 class TransactionManager(
     private val storeKitManager: StoreKitManager,
+    private val purchaseController: PurchaseController,
     private val sessionEventsManager: SessionEventsManager,
     private val activityProvider: ActivityProvider,
     private val factory: Factory
@@ -54,6 +58,12 @@ class TransactionManager(
         when (result) {
             is PurchaseResult.Purchased -> {
                 didPurchase(product, paywallViewController)
+            }
+            is PurchaseResult.Restored -> {
+                didRestore(
+                    product = product,
+                    paywallViewController = paywallViewController
+                )
             }
             is PurchaseResult.Failed -> {
                 val superwallOptions = factory.makeSuperwallOptions()
@@ -87,6 +97,41 @@ class TransactionManager(
             is PurchaseResult.Cancelled -> {
                 trackCancelled(product, paywallViewController)
             }
+        }
+    }
+
+    private suspend fun didRestore(
+        product: StoreProduct? = null,
+        paywallViewController: PaywallViewController
+    ) {
+        val purchasingCoordinator = factory.makeTransactionVerifier()
+        var transaction: StoreTransaction? = null
+        val restoreType: RestoreType
+
+        if (product != null) {
+            // Product exists so much have been via a purchase of a specific product.
+            transaction = purchasingCoordinator.getLatestTransaction(
+                factory = factory
+            )
+            restoreType = RestoreType.ViaPurchase(transaction)
+        } else {
+            // Otherwise it was a generic restore.
+            restoreType = RestoreType.ViaRestore
+        }
+
+        val paywallInfo = paywallViewController.info
+
+        val trackedEvent = InternalSuperwallEvent.Transaction(
+            state = InternalSuperwallEvent.Transaction.State.Restore(restoreType),
+            paywallInfo = paywallInfo,
+            product = product,
+            model = null
+        )
+        Superwall.instance.track(trackedEvent)
+
+        val superwallOptions = factory.makeSuperwallOptions()
+        if (superwallOptions.paywalls.automaticallyDismiss) {
+            Superwall.instance.dismiss(paywallViewController, result = PaywallResult.Restored())
         }
     }
 
@@ -246,6 +291,42 @@ class TransactionManager(
             "Waiting for Approval",
             "Thank you! This purchase is pending approval from your parent. Please try again once it is approved."
         )
+    }
+
+    suspend fun tryToRestore(paywallViewController: PaywallViewController) {
+        Logger.debug(
+            logLevel = LogLevel.debug,
+            scope = LogScope.paywallTransactions,
+            message = "Attempting Restore"
+        )
+
+        paywallViewController.loadingState = PaywallLoadingState.LoadingPurchase()
+
+        val restorationResult = purchaseController.restorePurchases()
+
+        val hasRestored = restorationResult is RestorationResult.Restored
+        val isUserSubscribed = Superwall.instance.subscriptionStatus.value == SubscriptionStatus.ACTIVE
+
+        if (hasRestored && isUserSubscribed) {
+            Logger.debug(
+                logLevel = LogLevel.debug,
+                scope = LogScope.paywallTransactions,
+                message = "Transactions Restored"
+            )
+            didRestore(paywallViewController = paywallViewController)
+        } else {
+            Logger.debug(
+                logLevel = LogLevel.debug,
+                scope = LogScope.paywallTransactions,
+                message = "Transactions Failed to Restore"
+            )
+
+            paywallViewController.presentAlert(
+                title = Superwall.instance.options.paywalls.restoreFailed.title,
+                message = Superwall.instance.options.paywalls.restoreFailed.message,
+                closeActionTitle = Superwall.instance.options.paywalls.restoreFailed.closeButtonTitle
+            )
+        }
     }
 
     private suspend fun presentAlert(


### PR DESCRIPTION
- Refactored the `TransactionManager` and `InternalPurchaseController` so that `Restored` can be returned as a `PurchaseResult` to match the iOS implementation.