### PR TITLE
v1.0.0-alpha.36

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 The changelog for `Superwall`. Also see the [releases](https://github.com/superwall-me/Superwall-Android/releases) on GitHub.
 
+## 1.0.0-alpha.36
+
+### Enhancements
+
+- Adds `X-Subscription-Status` header to all requests.
+- Caches the last `subscriptionStatus`.
+- Adds `subscriptionStatus_didChange` event that is fired whenever the subscription status changes.
+- Calls the delegate method `subscriptionStatusDidChange` whenever the subscription status changes.
+- SW-2676: Adds a completion block to the `configure` method.
+
+### Fixes
+
+- Fixes issue where the main thread was blocked when accessing some properties internally.
+- SW-2679: Fixes issue where the `subscription_start` event was being fired even if a non-recurring product was
+purchased.
+
 ## 1.0.0-alpha.35
 
 ### Fixes

--- a/superwall/build.gradle.kts
+++ b/superwall/build.gradle.kts
@@ -19,7 +19,7 @@ plugins {
     id("maven-publish")
 }
 
-version = "1.0.0-alpha.35"
+version = "1.0.0-alpha.36"
 
 android {
     compileSdk = 33

--- a/superwall/src/main/java/com/superwall/sdk/dependencies/DependencyContainer.kt
+++ b/superwall/src/main/java/com/superwall/sdk/dependencies/DependencyContainer.kt
@@ -238,6 +238,7 @@ class DependencyContainer(
             "X-Bundle-ID" to deviceHelper.bundleId,
             "X-Low-Power-Mode" to deviceHelper.isLowPowerModeEnabled.toString(),
             "X-Is-Sandbox" to deviceHelper.isSandbox.toString(),
+            "X-Subscription-Status" to Superwall.instance.subscriptionStatus.value.toString(),
             "Content-Type" to "application/json"
         )
 

--- a/superwall/src/main/java/com/superwall/sdk/paywall/vc/web_view/messaging/PaywallMessageHandler.kt
+++ b/superwall/src/main/java/com/superwall/sdk/paywall/vc/web_view/messaging/PaywallMessageHandler.kt
@@ -45,7 +45,6 @@ class PaywallMessageHandler(
 
     public var delegate: PaywallMessageHandlerDelegate? = null
 
-
     @JavascriptInterface
     fun postMessage(message: String) {
 
@@ -76,12 +75,12 @@ class PaywallMessageHandler(
         println("!! PaywallMessageHandler: delegeate: $delegate")
         when (message) {
             is PaywallMessage.TemplateParamsAndUserAttributes ->
-                MainScope().launch { passTemplatesToWebView(paywall) }
+                CoroutineScope(Dispatchers.IO).launch { passTemplatesToWebView(paywall) }
             is PaywallMessage.OnReady -> {
                 delegate?.paywall?.paywalljsVersion = message.paywallJsVersion
                 val loadedAt = Date()
                 println("!!Ready!!")
-                MainScope().launch { didLoadWebView(paywall, loadedAt) }
+                CoroutineScope(Dispatchers.IO).launch { didLoadWebView(paywall, loadedAt) }
             }
             is PaywallMessage.Close -> {
                 hapticFeedback()

--- a/superwall/src/main/java/com/superwall/sdk/store/transactions/TransactionManager.kt
+++ b/superwall/src/main/java/com/superwall/sdk/store/transactions/TransactionManager.kt
@@ -399,23 +399,25 @@ class TransactionManager(
                 product
             )
             Superwall.instance.track(nonRecurringEvent)
-        }
-
-        if (didStartFreeTrial) {
-            val freeTrialEvent = InternalSuperwallEvent.FreeTrialStart(paywallInfo, product)
-            Superwall.instance.track(freeTrialEvent)
-
-            val notifications = paywallInfo.localNotifications.filter { it.type == LocalNotificationType.TrialStarted }
-            val paywallActivity = (paywallViewController.encapsulatingActivity as SuperwallPaywallActivity)
-            paywallActivity.attemptToScheduleNotifications(
-                notifications = notifications,
-                factory = factory,
-                context = context
-            )
         } else {
-            val subscriptionEvent =
-                InternalSuperwallEvent.SubscriptionStart(paywallInfo, product)
-            Superwall.instance.track(subscriptionEvent)
+            if (didStartFreeTrial) {
+                val freeTrialEvent = InternalSuperwallEvent.FreeTrialStart(paywallInfo, product)
+                Superwall.instance.track(freeTrialEvent)
+
+                val notifications =
+                    paywallInfo.localNotifications.filter { it.type == LocalNotificationType.TrialStarted }
+                val paywallActivity =
+                    (paywallViewController.encapsulatingActivity as SuperwallPaywallActivity)
+                paywallActivity.attemptToScheduleNotifications(
+                    notifications = notifications,
+                    factory = factory,
+                    context = context
+                )
+            } else {
+                val subscriptionEvent =
+                    InternalSuperwallEvent.SubscriptionStart(paywallInfo, product)
+                Superwall.instance.track(subscriptionEvent)
+            }
         }
 
         lastPaywallViewController = null


### PR DESCRIPTION
### Enhancements

- Adds `X-Subscription-Status` header to all requests.
- Caches the last `subscriptionStatus`.
- Adds `subscriptionStatus_didChange` event that is fired whenever the subscription status changes.
- Calls the delegate method `subscriptionStatusDidChange` whenever the subscription status changes.
- SW-2676: Adds a completion block to the `configure` method.

### Fixes

- Fixes issue where the main thread was blocked when accessing some properties internally.
- SW-2679: Fixes issue where the `subscription_start` event was being fired even if a non-recurring product was
purchased.