### PR TITLE
v1.0.0-alpha.37

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 The changelog for `Superwall`. Also see the [releases](https://github.com/superwall-me/Superwall-Android/releases) on GitHub.
 
+## 1.0.0-alpha.37
+
+### Enhancements
+
+- SW-2684: Adds error logging if the `currentActivity` is `null` when trying to present a paywall.
+
+### Fixes
+
+- Fixes bug where all `paywallResponseLoad_` events were being counted as `paywallResponseLoad_start`.
+
 ## 1.0.0-alpha.36
 
 ### Enhancements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The changelog for `Superwall`. Also see the [releases](https://github.com/superw
 
 ### Fixes
 
+- Fixes bug where paywalls might not present on first app install.
 - Fixes bug where all `paywallResponseLoad_` events were being counted as `paywallResponseLoad_start`.
 
 ## 1.0.0-alpha.36

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The changelog for `Superwall`. Also see the [releases](https://github.com/superw
 
 - Fixes bug where paywalls might not present on first app install.
 - Fixes bug where all `paywallResponseLoad_` events were being counted as `paywallResponseLoad_start`.
+- Adds ProGuard rule to prevent `DefaultLifecycleObserver` from being removed.
 
 ## 1.0.0-alpha.36
 

--- a/superwall/build.gradle.kts
+++ b/superwall/build.gradle.kts
@@ -19,7 +19,7 @@ plugins {
     id("maven-publish")
 }
 
-version = "1.0.0-alpha.36"
+version = "1.0.0-alpha.37"
 
 android {
     compileSdk = 33

--- a/superwall/proguard-rules.pro
+++ b/superwall/proguard-rules.pro
@@ -19,3 +19,5 @@
 # If you keep the line number information, uncomment this to
 # hide the original source file name.
 #-renamesourcefileattribute SourceFile
+
+-keep class androidx.lifecycle.DefaultLifecycleObserver

--- a/superwall/src/main/java/com/superwall/sdk/analytics/internal/trackable/TrackableSuperwallEvent.kt
+++ b/superwall/src/main/java/com/superwall/sdk/analytics/internal/trackable/TrackableSuperwallEvent.kt
@@ -178,6 +178,23 @@ sealed class InternalSuperwallEvent(override val superwallEvent: SuperwallEvent)
             class Complete(val paywallInfo: PaywallInfo) : State()
         }
 
+        override val superwallEvent: SuperwallEvent
+            get() = when (state) {
+                is State.Start -> SuperwallEvent.PaywallResponseLoadStart(
+                    eventData?.name
+                )
+                is State.Complete -> SuperwallEvent.PaywallResponseLoadComplete(
+                    eventData?.name,
+                    state.paywallInfo
+                )
+                is State.Fail -> SuperwallEvent.PaywallResponseLoadFail(
+                    eventData?.name
+                )
+                is State.NotFound -> SuperwallEvent.PaywallResponseLoadNotFound(
+                    eventData?.name
+                )
+            }
+
         override val customParameters: Map<String, Any>
             get() = when (state) {
                 is State.Complete -> state.paywallInfo.customParams()

--- a/superwall/src/main/java/com/superwall/sdk/billing/GoogleBillingWrapper.kt
+++ b/superwall/src/main/java/com/superwall/sdk/billing/GoogleBillingWrapper.kt
@@ -84,7 +84,6 @@ open class GoogleBillingWrapper(open val context: Context, open val mainHandler:
         }
     }
 
-
     fun startConnectionOnMainThread(delayMilliseconds: Long, force: Boolean = false) {
         mainHandler.postDelayed(
             { startConnection() },

--- a/superwall/src/main/java/com/superwall/sdk/identity/IdentityManager.kt
+++ b/superwall/src/main/java/com/superwall/sdk/identity/IdentityManager.kt
@@ -102,7 +102,7 @@ class IdentityManager(
     }
 
     fun configure() {
-        CoroutineScope(queue).launch {
+        CoroutineScope(Dispatchers.IO).launch {
             val neverCalledStaticConfig = storage.neverCalledStaticConfig
             val isFirstAppOpen =
                 !(storage.get(DidTrackFirstSeen) ?: false)

--- a/superwall/src/main/java/com/superwall/sdk/paywall/presentation/internal/operators/GetPresenter.kt
+++ b/superwall/src/main/java/com/superwall/sdk/paywall/presentation/internal/operators/GetPresenter.kt
@@ -66,7 +66,17 @@ suspend fun Superwall.getPresenterIfNecessary(
     )
     paywallViewController.paywall.triggerSessionId = sessionId
 
-    return dependencyContainer.activityProvider?.getCurrentActivity()
+    val currentActivity = dependencyContainer.activityProvider?.getCurrentActivity()
+
+    if (currentActivity == null) {
+        Logger.debug(
+            logLevel = LogLevel.error,
+            scope = LogScope.paywallPresentation,
+            message = "Current Activity is null, can't present paywall"
+        )
+        throw PaywallPresentationRequestStatusReason.NoPresenter()
+    }
+    return currentActivity
 }
 
 

--- a/superwall/src/main/java/com/superwall/sdk/paywall/vc/PaywallViewController.kt
+++ b/superwall/src/main/java/com/superwall/sdk/paywall/vc/PaywallViewController.kt
@@ -470,6 +470,7 @@ class PaywallViewController(
 
     private suspend fun trackOpen() {
         storage.trackPaywallOpen()
+        webView.messageHandler.handle(PaywallMessage.PaywallOpen)
         val trackedEvent = InternalSuperwallEvent.PaywallOpen(info)
         Superwall.instance.track(trackedEvent)
     }

--- a/superwall/src/main/java/com/superwall/sdk/paywall/vc/web_view/messaging/PaywallMessage.kt
+++ b/superwall/src/main/java/com/superwall/sdk/paywall/vc/web_view/messaging/PaywallMessage.kt
@@ -24,6 +24,7 @@ sealed class PaywallMessage {
     data class OpenDeepLink(val url: Uri) : PaywallMessage()
     data class Purchase(val product: String, val productId: String) : PaywallMessage()
     data class Custom(val data: String) : PaywallMessage()
+    object PaywallOpen : PaywallMessage()
 }
 
 fun parseWrappedPaywallMessages(jsonString: String): WrappedPaywallMessages {


### PR DESCRIPTION
### Enhancements

- SW-2684: Adds error logging if the `currentActivity` is `null` when trying to present a paywall.

### Fixes

- Fixes bug where paywalls might not present on first app install.
- Fixes bug where all `paywallResponseLoad_` events were being counted as `paywallResponseLoad_start`.