### PR TITLE
v1.0.0-alpha.38

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 The changelog for `Superwall`. Also see the [releases](https://github.com/superwall-me/Superwall-Android/releases) on GitHub.
 
+## 1.0.0-alpha.39
+
+### Fixes
+
+- Removes use of `USE_EXACT_ALARM` permission that was getting apps rejected.
+- Fixes issue with scheduling notifications. The paywall wasn't waiting to schedule notifications 
+before dismissal so the permissions wasn't always showing.
+
 ## 1.0.0-alpha.38
 
 ### Enhancements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 The changelog for `Superwall`. Also see the [releases](https://github.com/superwall-me/Superwall-Android/releases) on GitHub.
 
+## 1.0.0-alpha.38
+
+### Enhancements
+
+- SW-2682: Adds `Superwall.instance.latestPaywallInfo`, which you can use to get the `PaywallInfo` of
+the most recently presented view controller.
+- SW-2683: Adds `Superwall.instance.isLoggedIn`, which you can use to check if the user is logged in.
+
 ## 1.0.0-alpha.37
 
 ### Enhancements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,14 +2,6 @@
 
 The changelog for `Superwall`. Also see the [releases](https://github.com/superwall-me/Superwall-Android/releases) on GitHub.
 
-## 1.0.0-alpha.39
-
-### Fixes
-
-- Removes use of `USE_EXACT_ALARM` permission that was getting apps rejected.
-- Fixes issue with scheduling notifications. The paywall wasn't waiting to schedule notifications 
-before dismissal so the permissions wasn't always showing.
-
 ## 1.0.0-alpha.38
 
 ### Enhancements
@@ -17,6 +9,12 @@ before dismissal so the permissions wasn't always showing.
 - SW-2682: Adds `Superwall.instance.latestPaywallInfo`, which you can use to get the `PaywallInfo` of
 the most recently presented view controller.
 - SW-2683: Adds `Superwall.instance.isLoggedIn`, which you can use to check if the user is logged in.
+
+### Fixes
+
+- Removes use of `USE_EXACT_ALARM` permission that was getting apps rejected.
+- Fixes issue with scheduling notifications. The paywall wasn't waiting to schedule notifications
+  before dismissal so the permissions wasn't always showing.
 
 ## 1.0.0-alpha.37
 

--- a/superwall/build.gradle.kts
+++ b/superwall/build.gradle.kts
@@ -19,7 +19,7 @@ plugins {
     id("maven-publish")
 }
 
-version = "1.0.0-alpha.39"
+version = "1.0.0-alpha.38"
 
 android {
     compileSdk = 33

--- a/superwall/build.gradle.kts
+++ b/superwall/build.gradle.kts
@@ -19,7 +19,7 @@ plugins {
     id("maven-publish")
 }
 
-version = "1.0.0-alpha.37"
+version = "1.0.0-alpha.38"
 
 android {
     compileSdk = 33

--- a/superwall/build.gradle.kts
+++ b/superwall/build.gradle.kts
@@ -19,7 +19,7 @@ plugins {
     id("maven-publish")
 }
 
-version = "1.0.0-alpha.38"
+version = "1.0.0-alpha.39"
 
 android {
     compileSdk = 33

--- a/superwall/src/main/AndroidManifest.xml
+++ b/superwall/src/main/AndroidManifest.xml
@@ -2,7 +2,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
-    <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM"
-        android:maxSdkVersion="32" />
-    <uses-permission android:name="android.permission.USE_EXACT_ALARM" />
+    <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM" />
 </manifest>

--- a/superwall/src/main/java/com/superwall/sdk/Superwall.kt
+++ b/superwall/src/main/java/com/superwall/sdk/Superwall.kt
@@ -17,6 +17,7 @@ import com.superwall.sdk.dependencies.DependencyContainer
 import com.superwall.sdk.misc.ActivityProvider
 import com.superwall.sdk.misc.SerialTaskManager
 import com.superwall.sdk.paywall.presentation.PaywallCloseReason
+import com.superwall.sdk.paywall.presentation.PaywallInfo
 import com.superwall.sdk.paywall.presentation.PresentationItems
 import com.superwall.sdk.paywall.presentation.internal.dismiss
 import com.superwall.sdk.paywall.presentation.internal.state.PaywallResult
@@ -147,6 +148,24 @@ class Superwall(
       */
     val userId: String
         get() = dependencyContainer.identityManager.userId
+
+    /**
+     * Indicates whether the user is logged in to Superwall.
+     *
+     * If you have previously called `identify(userId:options:)`, this will
+     * return `true`.
+    */
+    val isLoggedIn: Boolean
+        get() = dependencyContainer.identityManager.isLoggedIn
+
+    /**
+     * The `PaywallInfo` object of the most recently presented view controller.
+      */
+    val latestPaywallInfo: PaywallInfo?
+        get() {
+            val presentedPaywallInfo = dependencyContainer.paywallManager.presentedViewController?.info
+            return presentedPaywallInfo ?: presentationItems.paywallInfo
+        }
 
     protected var _subscriptionStatus: MutableStateFlow<SubscriptionStatus> = MutableStateFlow(
         SubscriptionStatus.UNKNOWN

--- a/superwall/src/main/java/com/superwall/sdk/analytics/internal/Tracking.kt
+++ b/superwall/src/main/java/com/superwall/sdk/analytics/internal/Tracking.kt
@@ -11,7 +11,6 @@ import com.superwall.sdk.models.events.EventData
 import com.superwall.sdk.paywall.presentation.dismiss
 import com.superwall.sdk.paywall.presentation.dismissForNextPaywall
 import com.superwall.sdk.paywall.presentation.internal.PresentationRequestType
-import com.superwall.sdk.paywall.presentation.internal.dismiss
 import com.superwall.sdk.paywall.presentation.internal.internallyPresent
 import com.superwall.sdk.paywall.presentation.internal.operators.logErrors
 import com.superwall.sdk.paywall.presentation.internal.operators.waitForSubsStatusAndConfig
@@ -20,12 +19,9 @@ import com.superwall.sdk.paywall.presentation.internal.state.PaywallState
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableSharedFlow
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
-import kotlinx.serialization.json.JsonObject
 import java.util.*
 
 suspend fun Superwall.track(event: Trackable): TrackingResult {
@@ -63,7 +59,7 @@ suspend fun Superwall.track(event: Trackable): TrackingResult {
         parameters = parameters.eventParams,
         createdAt = eventCreatedAt
     )
-    dependencyContainer.queue.enqueue(event = eventData)
+    dependencyContainer.eventsQueue.enqueue(event = eventData)
     dependencyContainer.storage.coreDataManager.saveEventData(eventData)
 
     if (event.canImplicitlyTriggerPaywall) {
@@ -75,11 +71,10 @@ suspend fun Superwall.track(event: Trackable): TrackingResult {
         }
     }
 
-    val result = TrackingResult(
+    return TrackingResult(
         data = eventData,
         parameters = parameters
     )
-    return result
 }
 
 suspend fun Superwall.handleImplicitTrigger(

--- a/superwall/src/main/java/com/superwall/sdk/analytics/internal/Tracking.kt
+++ b/superwall/src/main/java/com/superwall/sdk/analytics/internal/Tracking.kt
@@ -123,7 +123,7 @@ private suspend fun Superwall.internallyHandleImplicitTrigger(
             dismiss()
         }
         TrackingLogic.ImplicitTriggerOutcome.ClosePaywallThenTriggerPaywall -> {
-            val lastPresentationItems = presentationItems.getLast() ?: return@withContext
+            val lastPresentationItems = presentationItems.last ?: return@withContext
             dismissForNextPaywall()
             statePublisher = lastPresentationItems.statePublisher
         }

--- a/superwall/src/main/java/com/superwall/sdk/dependencies/DependencyContainer.kt
+++ b/superwall/src/main/java/com/superwall/sdk/dependencies/DependencyContainer.kt
@@ -89,7 +89,7 @@ class DependencyContainer(
     var appSessionManager: AppSessionManager
     var sessionEventsManager: SessionEventsManager
     var delegateAdapter: SuperwallDelegateAdapter
-    var queue: EventsQueue
+    var eventsQueue: EventsQueue
     var debugManager: DebugManager
     var paywallManager: PaywallManager
     var paywallRequestManager: PaywallRequestManager
@@ -158,7 +158,7 @@ class DependencyContainer(
 
         deviceHelper = DeviceHelper(context = context, storage = storage, factory = this)
 
-        queue = EventsQueue(context, configManager = configManager, network = network)
+        eventsQueue = EventsQueue(context, configManager = configManager, network = network)
 
         identityManager = IdentityManager(
             storage = storage,
@@ -195,6 +195,7 @@ class DependencyContainer(
             storeKitManager = storeKitManager,
             purchaseController = purchaseController,
             sessionEventsManager,
+            eventsQueue = eventsQueue,
             activityProvider,
             factory = this,
             context = context

--- a/superwall/src/main/java/com/superwall/sdk/paywall/presentation/internal/operators/StorePresentationObjects.kt
+++ b/superwall/src/main/java/com/superwall/sdk/paywall/presentation/internal/operators/StorePresentationObjects.kt
@@ -19,5 +19,5 @@ internal suspend fun Superwall.storePresentationObjects(
         request,
         paywallStatePublisher
     )
-    presentationItems.setLast(lastPaywallPresentation)
+    presentationItems.last = lastPaywallPresentation
 }

--- a/superwall/src/main/java/com/superwall/sdk/paywall/vc/PaywallViewController.kt
+++ b/superwall/src/main/java/com/superwall/sdk/paywall/vc/PaywallViewController.kt
@@ -82,6 +82,8 @@ import kotlinx.coroutines.launch
 import java.net.MalformedURLException
 import java.net.URL
 import java.util.*
+import kotlin.coroutines.resume
+import kotlin.coroutines.suspendCoroutine
 
 
 class PaywallViewController(
@@ -927,12 +929,15 @@ class SuperwallPaywallActivity : AppCompatActivity() {
         fun onPermissionResult(granted: Boolean)
     }
 
-    fun attemptToScheduleNotifications(
+    suspend fun attemptToScheduleNotifications(
         notifications: List<LocalNotification>,
         factory: DeviceHelperFactory,
         context: Context
-    ) {
-        if (notifications.isEmpty()) return
+    ) = suspendCoroutine { continuation ->
+        if (notifications.isEmpty()) {
+            continuation.resume(Unit) // Resume immediately as there's nothing to schedule
+            return@suspendCoroutine
+        }
 
         createNotificationChannel()
 
@@ -945,11 +950,13 @@ class SuperwallPaywallActivity : AppCompatActivity() {
                         context = context
                     )
                 }
+                continuation.resume(Unit) // Resume coroutine after processing
             }
         }
 
         checkAndRequestNotificationPermissions(this, notificationPermissionCallback!!)
     }
+
 
     private fun createNotificationChannel() {
         val importance = NotificationManager.IMPORTANCE_DEFAULT

--- a/superwall/src/main/java/com/superwall/sdk/paywall/vc/PaywallViewController.kt
+++ b/superwall/src/main/java/com/superwall/sdk/paywall/vc/PaywallViewController.kt
@@ -289,11 +289,11 @@ class PaywallViewController(
         presentationWillPrepare = false
     }
 
-    internal suspend fun viewWillDisappear() {
+    internal fun viewWillDisappear() {
         if (isSafariVCPresented) {
             return
         }
-        Superwall.instance.presentationItems.setPaywallInfo(info)
+        Superwall.instance.presentationItems.paywallInfo = info
         Superwall.instance.dependencyContainer.delegateAdapter.willDismissPaywall(info)
     }
 

--- a/superwall/src/main/java/com/superwall/sdk/storage/EventsQueue.kt
+++ b/superwall/src/main/java/com/superwall/sdk/storage/EventsQueue.kt
@@ -50,7 +50,7 @@ class EventsQueue(
         }
     }
 
-    private suspend fun addObserver() {
+    private fun addObserver() {
         val filter = IntentFilter().apply {
             addAction(Intent.ACTION_SCREEN_OFF)
         }
@@ -71,7 +71,7 @@ class EventsQueue(
         }
     }
 
-    private suspend fun flushInternal(depth: Int = 10) {
+    suspend fun flushInternal(depth: Int = 10) {
         val eventsToSend = mutableListOf<EventData>()
         var i = 0
         while (i < maxEventCount && elements.isNotEmpty()) {

--- a/superwall/src/main/java/com/superwall/sdk/store/transactions/TransactionManager.kt
+++ b/superwall/src/main/java/com/superwall/sdk/store/transactions/TransactionManager.kt
@@ -25,6 +25,7 @@ import com.superwall.sdk.paywall.presentation.internal.state.PaywallResult
 import com.superwall.sdk.paywall.vc.PaywallViewController
 import com.superwall.sdk.paywall.vc.SuperwallPaywallActivity
 import com.superwall.sdk.paywall.vc.delegate.PaywallLoadingState
+import com.superwall.sdk.storage.EventsQueue
 import com.superwall.sdk.store.StoreKitManager
 import com.superwall.sdk.store.abstractions.product.StoreProduct
 import com.superwall.sdk.store.abstractions.transactions.StoreTransaction
@@ -34,6 +35,7 @@ class TransactionManager(
     private val storeKitManager: StoreKitManager,
     private val purchaseController: PurchaseController,
     private val sessionEventsManager: SessionEventsManager,
+    private val eventsQueue: EventsQueue,
     private val activityProvider: ActivityProvider,
     private val factory: Factory,
     private val context: Context
@@ -392,6 +394,9 @@ class TransactionManager(
             transaction
         )
         Superwall.instance.track(trackedEvent)
+
+        // Immediately flush the events queue on transaction complete.
+        eventsQueue.flushInternal()
 
         if (product.subscriptionPeriod == null) {
             val nonRecurringEvent = InternalSuperwallEvent.NonRecurringProductPurchase(


### PR DESCRIPTION
### Enhancements

- SW-2682: Adds `Superwall.instance.latestPaywallInfo`, which you can use to get the `PaywallInfo` of
the most recently presented view controller.
- SW-2683: Adds `Superwall.instance.isLoggedIn`, which you can use to check if the user is logged in.

### Fixes

- Removes use of `USE_EXACT_ALARM` permission that was getting an app rejected.
- Fixes issue with scheduling notifications. The paywall wasn't waiting to schedule notifications 
before dismissal so the permissions wasn't always showing.
- Immediately flushes the events queue on transaction complete.