### PR TITLE
v1.0.0-alpha.45

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 The changelog for `Superwall`. Also see the [releases](https://github.com/superwall-me/Superwall-Android/releases) on GitHub.
 
+## 1.0.0-alpha.45
+
+### Fixes
+
+- Fixes issue where the `paywallProductsLoad_fail` event wasn't correctly being logged. This is a
+"soft fail", meaning that even though it gets logged, your paywall will still show. The error message
+with the event has been updated to include all product subscription IDs that are failing to be retrieved.
+
 ## 1.0.0-alpha.44
 
 ### Fixes

--- a/superwall/build.gradle.kts
+++ b/superwall/build.gradle.kts
@@ -19,7 +19,7 @@ plugins {
     id("maven-publish")
 }
 
-version = "1.0.0-alpha.44"
+version = "1.0.0-alpha.45"
 
 android {
     compileSdk = 33

--- a/superwall/src/main/java/com/superwall/sdk/debug/DebugViewController.kt
+++ b/superwall/src/main/java/com/superwall/sdk/debug/DebugViewController.kt
@@ -64,6 +64,7 @@ import android.widget.TextView
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.app.AppCompatDelegate
 import com.superwall.sdk.debug.localizations.SWLocalizationActivity
+import com.superwall.sdk.dependencies.TriggerSessionManagerFactory
 import kotlinx.coroutines.withContext
 
 interface AppCompatActivityEncapsulatable {
@@ -79,7 +80,7 @@ class DebugViewController(
     private val debugManager: DebugManager,
     private val factory: Factory
 ) : ConstraintLayout(context), AppCompatActivityEncapsulatable {
-    interface Factory: RequestFactory, ViewControllerFactory {}
+    interface Factory: RequestFactory, ViewControllerFactory, TriggerSessionManagerFactory {}
     data class AlertOption(
         val title: String? = "",
         val action: (suspend () -> Unit)? = null,
@@ -418,7 +419,11 @@ class DebugViewController(
             )
             var paywall = paywallRequestManager.getPaywall(request)
 
-            val productVariables = storeKitManager.getProductVariables(paywall)
+            val productVariables = storeKitManager.getProductVariables(
+                paywall,
+                request = request,
+                factory = factory
+            )
             paywall.productVariables = productVariables
 
             this.paywall = paywall
@@ -565,7 +570,8 @@ class DebugViewController(
         }
 
         val (productsById, _) = storeKitManager.getProducts(
-            responseProductIds = paywall.productIds
+            paywall = paywall,
+            factory = factory
         )
         val products = paywall.productIds.mapNotNull { productsById[it] }
         SWConsoleActivity.products = products

--- a/superwall/src/main/java/com/superwall/sdk/store/StoreKitManagerInterface.kt
+++ b/superwall/src/main/java/com/superwall/sdk/store/StoreKitManagerInterface.kt
@@ -11,7 +11,8 @@ import com.superwall.sdk.store.abstractions.product.StoreProduct
 
 data class GetProductsResponse(
     val productsById: Map<String, StoreProduct>,
-    val products: List<Product>
+    val products: List<Product>,
+    val paywall: Paywall
 )
 
 interface StoreKitManagerInterface {

--- a/superwall/src/main/java/com/superwall/sdk/store/products/GooglePlayProductsFetcher.kt
+++ b/superwall/src/main/java/com/superwall/sdk/store/products/GooglePlayProductsFetcher.kt
@@ -242,18 +242,20 @@ open class GooglePlayProductsFetcher(
                 .toMap()
                 .toMutableMap() as MutableMap<String, Result<RawStoreProduct>>
 
+            val missingProductsString = missingProducts.joinToString(separator = ", ")
             missingProducts.forEach { missingProductId ->
                 productIdsBySubscriptionId[missingProductId]?.forEach { product ->
-                    subscriptionIdToResult[product.fullId] = Result.Error(Exception("Failed to query product details"))
+                    subscriptionIdToResult[product.fullId] = Result.Error(Exception("Failed to query product details for $missingProductsString"))
                 }
             }
 
             return subscriptionIdToResult.toMap()
         } else {
+            val missingProductsString = subscriptionIds.joinToString(separator = ", ")
             val results: MutableMap<String, Result<RawStoreProduct>> = mutableMapOf()
             subscriptionIds.forEach { subscriptionId ->
                 productIdsBySubscriptionId[subscriptionId]?.forEach { product ->
-                    results[product.fullId] = Result.Error(Exception("Failed to query product details. Billing response code: ${billingResult.responseCode}"))
+                    results[product.fullId] = Result.Error(Exception("Failed to query product details for $missingProductsString. Billing response code: ${billingResult.responseCode}"))
                 }
             }
             return results
@@ -271,6 +273,7 @@ open class GooglePlayProductsFetcher(
         return productResults.values.mapNotNull {
             when (it) {
                 is Result.Success -> StoreProduct(it.value) // Assuming RawStoreProduct can be converted to StoreProduct
+                is Result.Error -> throw it.error
                 else -> null
             }
         }.toSet()


### PR DESCRIPTION
### Fixes

- Fixes issue where the `paywallProductsLoad_fail` event wasn't correctly being logged. This is a
"soft fail", meaning that even though it gets logged, your paywall will still show. The error message
with the event has been updated to include all product subscription IDs that are failing to be retrieved.