### PR TITLE
v1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,13 @@
 
 The changelog for `Superwall`. Also see the [releases](https://github.com/superwall-me/Superwall-Android/releases) on GitHub.
 
-## 1.0.0-rc.1
+## 1.0.0
 
 ### Fixes
 
 - Fixes rare thread-safety crash when sending events back to Superwall's servers.
 - Calls the `onError` presentation handler block when there's no activity to present a paywall on.
+- Fixes issue where the wrong product may be presented to purchase if a free trial had already been used.
 
 ## 1.0.0-alpha.45
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,11 @@ The changelog for `Superwall`. Also see the [releases](https://github.com/superw
 
 - Fixes rare thread-safety crash when sending events back to Superwall's servers.
 - Calls the `onError` presentation handler block when there's no activity to present a paywall on.
-- Fixes issue where the wrong product may be presented to purchase if a free trial had already been used.
+- Fixes issue where the wrong product may be presented to purchase if a free trial had already been 
+used and you were letting Superwall handle purchases.
+- Fixes `IllegalStateException` on Samsung devices when letting Superwall handle purchases.
+- Keeps the text zoom of paywalls to 100% rather than respecting the accessibility settings text zoom,
+which caused unexpected UI issues.
 
 ## 1.0.0-alpha.45
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,8 @@ used and you were letting Superwall handle purchases.
 - Fixes `IllegalStateException` on Samsung devices when letting Superwall handle purchases.
 - Keeps the text zoom of paywalls to 100% rather than respecting the accessibility settings text zoom,
 which caused unexpected UI issues.
-- Fixes rare `UninitializedPropertyAccessException` crash caused by a threading issue. 
+- Fixes rare `UninitializedPropertyAccessException` crash caused by a threading issue.
+- Fixes crash when the user has disabled the Android System WebView.
 
 ## 1.0.0-alpha.45
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 The changelog for `Superwall`. Also see the [releases](https://github.com/superwall-me/Superwall-Android/releases) on GitHub.
 
+## 1.0.0-rc.1
+
+### Fixes
+
+- Fixes rare thread-safety crash when sending events back to Superwall's servers.
+- Calls the `onError` presentation handler block when there's no activity to present a paywall on.
+
 ## 1.0.0-alpha.45
 
 ### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ The changelog for `Superwall`. Also see the [releases](https://github.com/superw
 
 ## 1.0.0
 
+### Breaking Changes
+
+- Changes the import path for the `LogScope`, and `LogLevel`.
+
 ### Fixes
 
 - Fixes rare thread-safety crash when sending events back to Superwall's servers.
@@ -13,6 +17,7 @@ used and you were letting Superwall handle purchases.
 - Fixes `IllegalStateException` on Samsung devices when letting Superwall handle purchases.
 - Keeps the text zoom of paywalls to 100% rather than respecting the accessibility settings text zoom,
 which caused unexpected UI issues.
+- Fixes rare `UninitializedPropertyAccessException` crash caused by a threading issue. 
 
 ## 1.0.0-alpha.45
 

--- a/app/src/main/java/com/superwall/superapp/test/UITestActivity.kt
+++ b/app/src/main/java/com/superwall/superapp/test/UITestActivity.kt
@@ -135,6 +135,7 @@ fun UITestTable() {
         UITestHandler.testAndroid20Info to { CoroutineScope(Dispatchers.IO).launch { UITestHandler.testAndroid20() } },
         UITestHandler.testAndroid21Info to { CoroutineScope(Dispatchers.IO).launch { UITestHandler.testAndroid21() } },
         UITestHandler.testAndroid22Info to { CoroutineScope(Dispatchers.IO).launch { UITestHandler.testAndroid22() } },
+        UITestHandler.testAndroid23Info to { CoroutineScope(Dispatchers.IO).launch { UITestHandler.testAndroid23() } },
     )
 
     LazyColumn {

--- a/app/src/main/java/com/superwall/superapp/test/UITestHandler.kt
+++ b/app/src/main/java/com/superwall/superapp/test/UITestHandler.kt
@@ -35,7 +35,7 @@ class UITestHandler {
         suspend fun test0() {
             Superwall.instance.identify(userId = "test0")
             Superwall.instance.setUserAttributes(attributes = mapOf("first_name" to "Jack"))
-            Superwall.instance.register(event = "present_data")
+            Superwall.instance.register(event = "consumable")
         }
 
         var test1Info = UITestInfo(
@@ -1424,6 +1424,19 @@ class UITestHandler {
         )
         suspend fun testAndroid22() {
             Superwall.instance.register(event = "notifications")
+        }
+
+        var testAndroid23Info = UITestInfo(
+            23,
+            "Tap button. You should see first_name: Jack printed out in user attributes " +
+                    "then the user attributes shouldn't contain first_name",
+            testCaseType = TestCaseType.Android
+        )
+        suspend fun testAndroid23() {
+            Superwall.instance.setUserAttributes(attributes = mapOf("first_name" to "Jack"))
+            println(Superwall.instance.userAttributes)
+            Superwall.instance.setUserAttributes(attributes = mapOf("first_name" to null))
+            println(Superwall.instance.userAttributes)
         }
     }
 }

--- a/superwall/build.gradle.kts
+++ b/superwall/build.gradle.kts
@@ -19,7 +19,7 @@ plugins {
     id("maven-publish")
 }
 
-version = "1.0.0-alpha.45"
+version = "1.0.0-rc.1"
 
 android {
     compileSdk = 33

--- a/superwall/build.gradle.kts
+++ b/superwall/build.gradle.kts
@@ -19,7 +19,7 @@ plugins {
     id("maven-publish")
 }
 
-version = "1.0.0-rc.1"
+version = "1.0.0"
 
 android {
     compileSdk = 33

--- a/superwall/src/main/java/com/superwall/sdk/Superwall.kt
+++ b/superwall/src/main/java/com/superwall/sdk/Superwall.kt
@@ -1,8 +1,5 @@
 package com.superwall.sdk
 
-import LogLevel
-import LogScope
-import Logger
 import android.content.Context
 import android.net.Uri
 import androidx.work.WorkManager
@@ -14,6 +11,9 @@ import com.superwall.sdk.delegate.SuperwallDelegate
 import com.superwall.sdk.delegate.SuperwallDelegateJava
 import com.superwall.sdk.delegate.subscription_controller.PurchaseController
 import com.superwall.sdk.dependencies.DependencyContainer
+import com.superwall.sdk.logger.LogLevel
+import com.superwall.sdk.logger.LogScope
+import com.superwall.sdk.logger.Logger
 import com.superwall.sdk.misc.ActivityProvider
 import com.superwall.sdk.misc.SerialTaskManager
 import com.superwall.sdk.paywall.presentation.PaywallCloseReason
@@ -36,6 +36,7 @@ import kotlinx.coroutines.flow.drop
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.take
 import java.util.*
+import java.util.concurrent.Executors
 
 class Superwall(
     internal var context: Context,
@@ -44,8 +45,7 @@ class Superwall(
     options: SuperwallOptions?,
     private var activityProvider: ActivityProvider?,
     private val completion: (() -> Unit)?
-) :
-    PaywallViewControllerEventDelegate {
+) : PaywallViewControllerEventDelegate {
     private var _options: SuperwallOptions? = options
     // Add a private variable for the purchase task
     private var purchaseTask: Job? = null
@@ -247,18 +247,27 @@ class Superwall(
         }
     }
 
-    internal lateinit var dependencyContainer: DependencyContainer
+    private lateinit var _dependencyContainer: DependencyContainer
+
+    internal val dependencyContainer: DependencyContainer
+        get() {
+            synchronized(this) {
+                return _dependencyContainer
+            }
+        }
 
     /// Used to serially execute register calls.
     internal val serialTaskManager = SerialTaskManager()
 
     internal fun setup() {
-        this.dependencyContainer = DependencyContainer(
-            context = context,
-            purchaseController = purchaseController,
-            options = _options,
-            activityProvider = activityProvider
-        )
+        synchronized(this) {
+            this._dependencyContainer = DependencyContainer(
+                context = context,
+                purchaseController = purchaseController,
+                options = _options,
+                activityProvider = activityProvider
+            )
+        }
 
         val cachedSubsStatus = dependencyContainer.storage.get(ActiveSubscriptionStatus) ?: SubscriptionStatus.UNKNOWN
         setSubscriptionStatus(cachedSubsStatus)

--- a/superwall/src/main/java/com/superwall/sdk/Superwall.kt
+++ b/superwall/src/main/java/com/superwall/sdk/Superwall.kt
@@ -2,6 +2,7 @@ package com.superwall.sdk
 
 import android.content.Context
 import android.net.Uri
+import android.webkit.WebView
 import androidx.work.WorkManager
 import com.superwall.sdk.analytics.internal.track
 import com.superwall.sdk.analytics.internal.trackable.InternalSuperwallEvent
@@ -222,7 +223,8 @@ class Superwall(
             activityProvider: ActivityProvider? = null,
             completion: (() -> Unit)? = null
         ) {
-            val purchaseController = purchaseController ?: ExternalNativePurchaseController(context = applicationContext)
+            val purchaseController =
+                purchaseController ?: ExternalNativePurchaseController(context = applicationContext)
             instance = Superwall(
                 context = applicationContext,
                 apiKey = apiKey,
@@ -231,6 +233,7 @@ class Superwall(
                 activityProvider = activityProvider,
                 completion = completion
             )
+
             instance.setup()
 
             Logger.debug(

--- a/superwall/src/main/java/com/superwall/sdk/analytics/internal/Tracking.kt
+++ b/superwall/src/main/java/com/superwall/sdk/analytics/internal/Tracking.kt
@@ -1,12 +1,12 @@
 package com.superwall.sdk.analytics.internal
 
-import LogLevel
-import LogScope
-import Logger
 import com.superwall.sdk.Superwall
 import com.superwall.sdk.analytics.internal.trackable.Trackable
 import com.superwall.sdk.analytics.internal.trackable.TrackableSuperwallEvent
 import com.superwall.sdk.analytics.superwall.SuperwallEventInfo
+import com.superwall.sdk.logger.LogLevel
+import com.superwall.sdk.logger.LogScope
+import com.superwall.sdk.logger.Logger
 import com.superwall.sdk.models.events.EventData
 import com.superwall.sdk.paywall.presentation.dismiss
 import com.superwall.sdk.paywall.presentation.dismissForNextPaywall

--- a/superwall/src/main/java/com/superwall/sdk/billing/GoogleBillingWrapper.kt
+++ b/superwall/src/main/java/com/superwall/sdk/billing/GoogleBillingWrapper.kt
@@ -165,7 +165,7 @@ open class GoogleBillingWrapper(open val context: Context, open val mainHandler:
                     Logger.debug(
                         LogLevel.error,
                         LogScope.productsManager,
-                        "Billing client error, item unavi supported or unavailable: ${billingResult.responseCode}",
+                        "Billing client error, item not supported or unavailable: ${billingResult.responseCode}",
                     )
                 }
 

--- a/superwall/src/main/java/com/superwall/sdk/billing/GoogleBillingWrapper.kt
+++ b/superwall/src/main/java/com/superwall/sdk/billing/GoogleBillingWrapper.kt
@@ -10,6 +10,9 @@ import com.android.billingclient.api.Purchase
 import com.android.billingclient.api.PurchasesUpdatedListener
 import com.superwall.sdk.delegate.InternalPurchaseResult
 import com.superwall.sdk.dependencies.StoreTransactionFactory
+import com.superwall.sdk.logger.LogLevel
+import com.superwall.sdk.logger.LogScope
+import com.superwall.sdk.logger.Logger
 import com.superwall.sdk.store.abstractions.transactions.StoreTransaction
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers

--- a/superwall/src/main/java/com/superwall/sdk/billing/GoogleBillingWrapper.kt
+++ b/superwall/src/main/java/com/superwall/sdk/billing/GoogleBillingWrapper.kt
@@ -21,8 +21,8 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlin.math.min
 
-private const val RECONNECT_TIMER_START_MILLISECONDS = 1L * 1000L
-private const val RECONNECT_TIMER_MAX_TIME_MILLISECONDS = 16L * 1000L
+internal const val RECONNECT_TIMER_START_MILLISECONDS = 1L * 1000L
+internal const val RECONNECT_TIMER_MAX_TIME_MILLISECONDS = 16L * 1000L
 
 open class GoogleBillingWrapper(open val context: Context, open val mainHandler: Handler = Handler(Looper.getMainLooper())): PurchasesUpdatedListener,
     BillingClientStateListener {

--- a/superwall/src/main/java/com/superwall/sdk/config/ConfigManager.kt
+++ b/superwall/src/main/java/com/superwall/sdk/config/ConfigManager.kt
@@ -1,8 +1,5 @@
 package com.superwall.sdk.config
 
-import LogLevel
-import LogScope
-import Logger
 import android.content.Context
 import com.superwall.sdk.config.models.ConfigState
 import com.superwall.sdk.config.models.getConfig
@@ -10,6 +7,9 @@ import com.superwall.sdk.config.options.SuperwallOptions
 import com.superwall.sdk.dependencies.DeviceInfoFactory
 import com.superwall.sdk.dependencies.RequestFactory
 import com.superwall.sdk.dependencies.RuleAttributesFactory
+import com.superwall.sdk.logger.LogLevel
+import com.superwall.sdk.logger.LogScope
+import com.superwall.sdk.logger.Logger
 import com.superwall.sdk.misc.Result
 import com.superwall.sdk.misc.awaitFirstValidConfig
 import com.superwall.sdk.models.assignment.AssignmentPostback

--- a/superwall/src/main/java/com/superwall/sdk/config/options/SuperwallOptions.kt
+++ b/superwall/src/main/java/com/superwall/sdk/config/options/SuperwallOptions.kt
@@ -1,7 +1,7 @@
 package com.superwall.sdk.config.options
 
-import LogLevel
-import LogScope
+import com.superwall.sdk.logger.LogLevel
+import com.superwall.sdk.logger.LogScope
 import java.util.*
 
 

--- a/superwall/src/main/java/com/superwall/sdk/contrib/threeteen/AmountFormats.kt
+++ b/superwall/src/main/java/com/superwall/sdk/contrib/threeteen/AmountFormats.kt
@@ -1,5 +1,8 @@
 package com.superwall.sdk.contrib.threeteen
 
+import com.superwall.sdk.logger.LogLevel
+import com.superwall.sdk.logger.LogScope
+import com.superwall.sdk.logger.Logger
 import org.threeten.bp.Period
 import java.time.Duration
 import java.time.format.DateTimeParseException

--- a/superwall/src/main/java/com/superwall/sdk/debug/DebugViewController.kt
+++ b/superwall/src/main/java/com/superwall/sdk/debug/DebugViewController.kt
@@ -1,7 +1,5 @@
 package com.superwall.sdk.debug
 
-import LogScope
-import android.app.Activity
 import android.app.AlertDialog
 import android.content.Context
 import android.content.Intent
@@ -10,7 +8,6 @@ import android.os.Bundle
 import android.view.View
 import android.view.Window
 import android.view.WindowManager
-import android.widget.Button
 import android.widget.FrameLayout
 import android.widget.ImageView
 import android.widget.ProgressBar
@@ -48,23 +45,18 @@ import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.launch
 import java.util.UUID
-import Logger
-import android.graphics.Outline
 import android.graphics.PorterDuff
 import android.graphics.PorterDuffColorFilter
-import android.graphics.drawable.ColorDrawable
 import android.graphics.drawable.GradientDrawable
-import android.net.Uri
-import android.os.Looper
-import android.util.DisplayMetrics
-import android.view.ViewOutlineProvider
-import android.widget.ImageButton
 import android.widget.LinearLayout
 import android.widget.TextView
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.app.AppCompatDelegate
 import com.superwall.sdk.debug.localizations.SWLocalizationActivity
 import com.superwall.sdk.dependencies.TriggerSessionManagerFactory
+import com.superwall.sdk.logger.LogLevel
+import com.superwall.sdk.logger.LogScope
+import com.superwall.sdk.logger.Logger
 import kotlinx.coroutines.withContext
 
 interface AppCompatActivityEncapsulatable {

--- a/superwall/src/main/java/com/superwall/sdk/delegate/SuperwallDelegateAdapter.kt
+++ b/superwall/src/main/java/com/superwall/sdk/delegate/SuperwallDelegateAdapter.kt
@@ -1,8 +1,5 @@
 package com.superwall.sdk.delegate
 
-import LogLevel
-import LogScope
-import Logger
 import com.superwall.sdk.analytics.superwall.SuperwallEventInfo
 import com.superwall.sdk.paywall.presentation.PaywallInfo
 import java.net.URL

--- a/superwall/src/main/java/com/superwall/sdk/game/GameControllerElementMapper.kt
+++ b/superwall/src/main/java/com/superwall/sdk/game/GameControllerElementMapper.kt
@@ -1,7 +1,9 @@
 package com.superwall.sdk.game
 
-import Logger
 import android.view.KeyEvent
+import com.superwall.sdk.logger.LogLevel
+import com.superwall.sdk.logger.LogScope
+import com.superwall.sdk.logger.Logger
 
 
 object GameControllerElementMapper {

--- a/superwall/src/main/java/com/superwall/sdk/identity/IdentityManager.kt
+++ b/superwall/src/main/java/com/superwall/sdk/identity/IdentityManager.kt
@@ -1,12 +1,12 @@
 package com.superwall.sdk.identity
 
-import LogLevel
-import LogScope
-import Logger
 import com.superwall.sdk.Superwall
 import com.superwall.sdk.analytics.internal.track
 import com.superwall.sdk.analytics.internal.trackable.InternalSuperwallEvent
 import com.superwall.sdk.config.ConfigManager
+import com.superwall.sdk.logger.LogLevel
+import com.superwall.sdk.logger.LogScope
+import com.superwall.sdk.logger.Logger
 import com.superwall.sdk.misc.awaitFirstValidConfig
 import com.superwall.sdk.misc.sha256MappedToRange
 import com.superwall.sdk.network.device.DeviceHelper

--- a/superwall/src/main/java/com/superwall/sdk/logger/LogLevel.kt
+++ b/superwall/src/main/java/com/superwall/sdk/logger/LogLevel.kt
@@ -1,3 +1,4 @@
+package com.superwall.sdk.logger
 enum class LogLevel(val level: Int) {
     debug(10),
     info(20),

--- a/superwall/src/main/java/com/superwall/sdk/logger/LogScope.kt
+++ b/superwall/src/main/java/com/superwall/sdk/logger/LogScope.kt
@@ -1,3 +1,5 @@
+package com.superwall.sdk.logger
+
 enum class LogScope {
     localizationManager,
     bounceButton,

--- a/superwall/src/main/java/com/superwall/sdk/logger/Logger.kt
+++ b/superwall/src/main/java/com/superwall/sdk/logger/Logger.kt
@@ -1,3 +1,5 @@
+package com.superwall.sdk.logger
+
 import com.superwall.sdk.Superwall
 import com.superwall.sdk.config.options.SuperwallOptions
 

--- a/superwall/src/main/java/com/superwall/sdk/network/Network.kt
+++ b/superwall/src/main/java/com/superwall/sdk/network/Network.kt
@@ -1,9 +1,9 @@
 package com.superwall.sdk.network
 
-import LogLevel
-import LogScope
-import Logger
 import com.superwall.sdk.dependencies.ApiFactory
+import com.superwall.sdk.logger.LogLevel
+import com.superwall.sdk.logger.LogScope
+import com.superwall.sdk.logger.Logger
 import com.superwall.sdk.models.assignment.Assignment
 import com.superwall.sdk.models.assignment.AssignmentPostback
 import com.superwall.sdk.models.assignment.ConfirmedAssignmentResponse
@@ -12,7 +12,6 @@ import com.superwall.sdk.models.events.EventData
 import com.superwall.sdk.models.events.EventsRequest
 import com.superwall.sdk.models.events.EventsResponse
 import com.superwall.sdk.models.paywall.Paywall
-import com.superwall.sdk.models.paywall.Paywalls
 import com.superwall.sdk.network.session.CustomHttpUrlConnection
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.first

--- a/superwall/src/main/java/com/superwall/sdk/network/session/CustomURLSession.kt
+++ b/superwall/src/main/java/com/superwall/sdk/network/session/CustomURLSession.kt
@@ -1,9 +1,8 @@
 package com.superwall.sdk.network.session
 
-
-import LogLevel
-import LogScope
-import Logger
+import com.superwall.sdk.logger.LogLevel
+import com.superwall.sdk.logger.LogScope
+import com.superwall.sdk.logger.Logger
 import com.superwall.sdk.misc.retrying
 import com.superwall.sdk.models.SerializableEntity
 import com.superwall.sdk.network.Endpoint

--- a/superwall/src/main/java/com/superwall/sdk/paywall/presentation/PaywallInfo.kt
+++ b/superwall/src/main/java/com/superwall/sdk/paywall/presentation/PaywallInfo.kt
@@ -1,11 +1,11 @@
 package com.superwall.sdk.paywall.presentation
 
 import ComputedPropertyRequest
-import LogLevel
-import LogScope
-import Logger
 import com.superwall.sdk.config.models.Survey
 import com.superwall.sdk.dependencies.TriggerSessionManagerFactory
+import com.superwall.sdk.logger.LogLevel
+import com.superwall.sdk.logger.LogScope
+import com.superwall.sdk.logger.Logger
 import com.superwall.sdk.misc.camelCaseToSnakeCase
 import com.superwall.sdk.models.config.FeatureGatingBehavior
 import com.superwall.sdk.models.events.EventData

--- a/superwall/src/main/java/com/superwall/sdk/paywall/presentation/get_presentation_result/InternalGetPresentationResult.kt
+++ b/superwall/src/main/java/com/superwall/sdk/paywall/presentation/get_presentation_result/InternalGetPresentationResult.kt
@@ -1,6 +1,9 @@
 package com.superwall.sdk.paywall.presentation.get_presentation_result
 
 import com.superwall.sdk.Superwall
+import com.superwall.sdk.logger.LogLevel
+import com.superwall.sdk.logger.LogScope
+import com.superwall.sdk.logger.Logger
 import com.superwall.sdk.paywall.presentation.internal.PaywallPresentationRequestStatusReason
 import com.superwall.sdk.paywall.presentation.internal.PresentationPipelineError
 import com.superwall.sdk.paywall.presentation.internal.PresentationRequest

--- a/superwall/src/main/java/com/superwall/sdk/paywall/presentation/internal/operators/CheckNoPaywallAlreadyPresented.kt
+++ b/superwall/src/main/java/com/superwall/sdk/paywall/presentation/internal/operators/CheckNoPaywallAlreadyPresented.kt
@@ -1,9 +1,9 @@
 package com.superwall.sdk.paywall.presentation.internal.operators
 
-import LogLevel
-import LogScope
-import Logger
 import com.superwall.sdk.Superwall
+import com.superwall.sdk.logger.LogLevel
+import com.superwall.sdk.logger.LogScope
+import com.superwall.sdk.logger.Logger
 import com.superwall.sdk.paywall.presentation.internal.InternalPresentationLogic
 import com.superwall.sdk.paywall.presentation.internal.PaywallPresentationRequestStatusReason
 import com.superwall.sdk.paywall.presentation.internal.PresentationRequest

--- a/superwall/src/main/java/com/superwall/sdk/paywall/presentation/internal/operators/CheckPaywallPresentable.kt
+++ b/superwall/src/main/java/com/superwall/sdk/paywall/presentation/internal/operators/CheckPaywallPresentable.kt
@@ -1,8 +1,5 @@
 package com.superwall.sdk.paywall.presentation.internal.operators
 
-import LogLevel
-import LogScope
-import Logger
 import android.app.Activity
 import com.superwall.sdk.Superwall
 import com.superwall.sdk.delegate.SubscriptionStatus

--- a/superwall/src/main/java/com/superwall/sdk/paywall/presentation/internal/operators/GetExperiment.kt
+++ b/superwall/src/main/java/com/superwall/sdk/paywall/presentation/internal/operators/GetExperiment.kt
@@ -1,6 +1,9 @@
 package com.superwall.sdk.paywall.presentation.internal.operators
 
 import com.superwall.sdk.Superwall
+import com.superwall.sdk.logger.LogLevel
+import com.superwall.sdk.logger.LogScope
+import com.superwall.sdk.logger.Logger
 import com.superwall.sdk.models.triggers.Experiment
 import com.superwall.sdk.models.triggers.InternalTriggerResult
 import com.superwall.sdk.paywall.presentation.internal.PaywallPresentationRequestStatusReason

--- a/superwall/src/main/java/com/superwall/sdk/paywall/presentation/internal/operators/GetPaywallVC.kt
+++ b/superwall/src/main/java/com/superwall/sdk/paywall/presentation/internal/operators/GetPaywallVC.kt
@@ -1,5 +1,6 @@
 package com.superwall.sdk.paywall.presentation.internal.operators
 
+import android.webkit.WebView
 import com.superwall.sdk.Superwall
 import com.superwall.sdk.delegate.SubscriptionStatus
 import com.superwall.sdk.dependencies.DependencyContainer
@@ -64,12 +65,23 @@ internal suspend fun Superwall.getPaywallViewController(
                 && request.flags.type != PresentationRequestType.GetPresentationResult
         val delegate = request.flags.type.paywallVcDelegateAdapter
 
-        dependencyContainer.paywallManager.getPaywallViewController(
-            request = paywallRequest,
-            isForPresentation = isForPresentation,
-            isPreloading = false,
-            delegate = delegate
-        )
+        val webviewExists = WebView.getCurrentWebViewPackage() != null
+        if (webviewExists) {
+            dependencyContainer.paywallManager.getPaywallViewController(
+                request = paywallRequest,
+                isForPresentation = isForPresentation,
+                isPreloading = false,
+                delegate = delegate
+            )
+        } else {
+            Logger.debug(
+                logLevel = LogLevel.error,
+                scope = LogScope.paywallPresentation,
+                message = "Paywalls cannot be presented because the Android System WebView has been disabled" +
+                        " by the user."
+            )
+            throw PaywallPresentationRequestStatusReason.NoPaywallViewController()
+        }
     } catch (e: Throwable) {
         if (subscriptionStatus == SubscriptionStatus.ACTIVE) {
             throw userIsSubscribed(paywallStatePublisher)

--- a/superwall/src/main/java/com/superwall/sdk/paywall/presentation/internal/operators/GetPaywallVC.kt
+++ b/superwall/src/main/java/com/superwall/sdk/paywall/presentation/internal/operators/GetPaywallVC.kt
@@ -1,11 +1,11 @@
 package com.superwall.sdk.paywall.presentation.internal.operators
 
-import LogLevel
-import LogScope
-import Logger
 import com.superwall.sdk.Superwall
 import com.superwall.sdk.delegate.SubscriptionStatus
 import com.superwall.sdk.dependencies.DependencyContainer
+import com.superwall.sdk.logger.LogLevel
+import com.superwall.sdk.logger.LogScope
+import com.superwall.sdk.logger.Logger
 import com.superwall.sdk.paywall.presentation.internal.InternalPresentationLogic
 import com.superwall.sdk.paywall.presentation.internal.PaywallPresentationRequestStatusReason
 import com.superwall.sdk.paywall.presentation.internal.PresentationRequest

--- a/superwall/src/main/java/com/superwall/sdk/paywall/presentation/internal/operators/GetPresenter.kt
+++ b/superwall/src/main/java/com/superwall/sdk/paywall/presentation/internal/operators/GetPresenter.kt
@@ -74,6 +74,14 @@ suspend fun Superwall.getPresenterIfNecessary(
             scope = LogScope.paywallPresentation,
             message = "Current Activity is null, can't present paywall"
         )
+        val error = InternalPresentationLogic.presentationError(
+            domain = "SWPresentationError",
+            code = 103,
+            title = "No Activity to present paywall on",
+            value = "This usually happens when you call this method before a window was made key and visible."
+        )
+        val state = PaywallState.PresentationError(error)
+        paywallStatePublisher?.emit(state)
         throw PaywallPresentationRequestStatusReason.NoPresenter()
     }
     return currentActivity

--- a/superwall/src/main/java/com/superwall/sdk/paywall/presentation/internal/operators/GetPresenter.kt
+++ b/superwall/src/main/java/com/superwall/sdk/paywall/presentation/internal/operators/GetPresenter.kt
@@ -3,6 +3,9 @@ package com.superwall.sdk.paywall.presentation.internal.operators
 import android.app.Activity
 import com.superwall.sdk.Superwall
 import com.superwall.sdk.delegate.SubscriptionStatus
+import com.superwall.sdk.logger.LogLevel
+import com.superwall.sdk.logger.LogScope
+import com.superwall.sdk.logger.Logger
 import com.superwall.sdk.models.assignment.ConfirmableAssignment
 import com.superwall.sdk.models.paywall.Paywall
 import com.superwall.sdk.models.triggers.InternalTriggerResult

--- a/superwall/src/main/java/com/superwall/sdk/paywall/presentation/internal/operators/HandleTriggerResult.kt
+++ b/superwall/src/main/java/com/superwall/sdk/paywall/presentation/internal/operators/HandleTriggerResult.kt
@@ -1,8 +1,5 @@
 package com.superwall.sdk.paywall.presentation.internal.operators
 
-import LogLevel
-import LogScope
-import Logger
 import com.superwall.sdk.Superwall
 import com.superwall.sdk.models.assignment.ConfirmableAssignment
 import com.superwall.sdk.models.triggers.Experiment

--- a/superwall/src/main/java/com/superwall/sdk/paywall/presentation/internal/operators/LogErrors.kt
+++ b/superwall/src/main/java/com/superwall/sdk/paywall/presentation/internal/operators/LogErrors.kt
@@ -1,11 +1,11 @@
 package com.superwall.sdk.paywall.presentation.internal.operators
 
-import LogLevel
-import LogScope
-import Logger
 import com.superwall.sdk.Superwall
 import com.superwall.sdk.analytics.internal.track
 import com.superwall.sdk.analytics.internal.trackable.InternalSuperwallEvent
+import com.superwall.sdk.logger.LogLevel
+import com.superwall.sdk.logger.LogScope
+import com.superwall.sdk.logger.Logger
 import com.superwall.sdk.paywall.presentation.internal.PaywallPresentationRequestStatus
 import com.superwall.sdk.paywall.presentation.internal.PaywallPresentationRequestStatusReason
 import com.superwall.sdk.paywall.presentation.internal.PresentationRequest

--- a/superwall/src/main/java/com/superwall/sdk/paywall/presentation/internal/operators/LogPresentation.kt
+++ b/superwall/src/main/java/com/superwall/sdk/paywall/presentation/internal/operators/LogPresentation.kt
@@ -1,9 +1,9 @@
 package com.superwall.sdk.paywall.presentation.internal.operators
 
-import LogLevel
-import LogScope
-import Logger
 import com.superwall.sdk.Superwall
+import com.superwall.sdk.logger.LogLevel
+import com.superwall.sdk.logger.LogScope
+import com.superwall.sdk.logger.Logger
 import com.superwall.sdk.paywall.presentation.internal.PresentationRequest
 
 // File.kt

--- a/superwall/src/main/java/com/superwall/sdk/paywall/presentation/internal/operators/PresentPaywall.kt
+++ b/superwall/src/main/java/com/superwall/sdk/paywall/presentation/internal/operators/PresentPaywall.kt
@@ -4,6 +4,9 @@ import android.app.Activity
 import com.superwall.sdk.Superwall
 import com.superwall.sdk.analytics.internal.track
 import com.superwall.sdk.analytics.internal.trackable.InternalSuperwallEvent
+import com.superwall.sdk.logger.LogLevel
+import com.superwall.sdk.logger.LogScope
+import com.superwall.sdk.logger.Logger
 import com.superwall.sdk.models.triggers.TriggerRuleOccurrence
 import com.superwall.sdk.paywall.presentation.internal.InternalPresentationLogic
 import com.superwall.sdk.paywall.presentation.internal.PaywallPresentationRequestStatus

--- a/superwall/src/main/java/com/superwall/sdk/paywall/presentation/internal/operators/WaitForSubsStatusAndConfig.kt
+++ b/superwall/src/main/java/com/superwall/sdk/paywall/presentation/internal/operators/WaitForSubsStatusAndConfig.kt
@@ -1,7 +1,5 @@
 package com.superwall.sdk.paywall.presentation.internal.operators
 
-import LogLevel
-import LogScope
 import com.superwall.sdk.Superwall
 import com.superwall.sdk.analytics.internal.track
 import com.superwall.sdk.analytics.internal.trackable.InternalSuperwallEvent
@@ -9,6 +7,9 @@ import com.superwall.sdk.config.models.ConfigState
 import com.superwall.sdk.config.models.getConfig
 import com.superwall.sdk.delegate.SubscriptionStatus
 import com.superwall.sdk.dependencies.DependencyContainer
+import com.superwall.sdk.logger.LogLevel
+import com.superwall.sdk.logger.LogScope
+import com.superwall.sdk.logger.Logger
 import com.superwall.sdk.misc.Result
 import com.superwall.sdk.paywall.presentation.internal.InternalPresentationLogic
 import com.superwall.sdk.paywall.presentation.internal.PaywallPresentationRequestStatus

--- a/superwall/src/main/java/com/superwall/sdk/paywall/presentation/internal/operators/WaitToPresent.kt
+++ b/superwall/src/main/java/com/superwall/sdk/paywall/presentation/internal/operators/WaitToPresent.kt
@@ -1,8 +1,5 @@
 package com.superwall.sdk.paywall.presentation.internal.operators
 
-import LogLevel
-import LogScope
-import Logger
 import com.superwall.sdk.Superwall
 import com.superwall.sdk.analytics.internal.track
 import com.superwall.sdk.analytics.internal.trackable.InternalSuperwallEvent

--- a/superwall/src/main/java/com/superwall/sdk/paywall/presentation/rule_logic/expression_evaluator/ExpressionEvaluator.kt
+++ b/superwall/src/main/java/com/superwall/sdk/paywall/presentation/rule_logic/expression_evaluator/ExpressionEvaluator.kt
@@ -39,15 +39,18 @@ class ExpressionEvaluator(
     }
 
     init {
-        // Setup the sharedWebView if it's not already setup
-        if (sharedWebView == null) {
-            runOnUiThread {
-                sharedWebView = WebView(context)
-                sharedWebView!!.settings.javaScriptEnabled = true
-                sharedWebView!!.webChromeClient = object : WebChromeClient() {
-                    override fun onConsoleMessage(consoleMessage: ConsoleMessage): Boolean {
-                        println("!!JS Console: ${consoleMessage.message()}")
-                        return true
+        val webviewExists = WebView.getCurrentWebViewPackage() != null
+        if (webviewExists) {
+            // Setup the sharedWebView if it's not already setup
+            if (sharedWebView == null) {
+                runOnUiThread {
+                    sharedWebView = WebView(context)
+                    sharedWebView!!.settings.javaScriptEnabled = true
+                    sharedWebView!!.webChromeClient = object : WebChromeClient() {
+                        override fun onConsoleMessage(consoleMessage: ConsoleMessage): Boolean {
+                            println("!!JS Console: ${consoleMessage.message()}")
+                            return true
+                        }
                     }
                 }
             }

--- a/superwall/src/main/java/com/superwall/sdk/paywall/presentation/rule_logic/expression_evaluator/ExpressionEvaluator.kt
+++ b/superwall/src/main/java/com/superwall/sdk/paywall/presentation/rule_logic/expression_evaluator/ExpressionEvaluator.kt
@@ -1,14 +1,14 @@
 package com.superwall.sdk.paywall.presentation.rule_logic.expression_evaluator
 
-import LogLevel
-import LogScope
-import Logger
 import android.content.Context
 import android.webkit.ConsoleMessage
 import android.webkit.ValueCallback
 import android.webkit.WebChromeClient
 import android.webkit.WebView
 import com.superwall.sdk.dependencies.RuleAttributesFactory
+import com.superwall.sdk.logger.LogLevel
+import com.superwall.sdk.logger.LogScope
+import com.superwall.sdk.logger.Logger
 import com.superwall.sdk.misc.runOnUiThread
 import com.superwall.sdk.models.events.EventData
 import com.superwall.sdk.models.triggers.TriggerRule

--- a/superwall/src/main/java/com/superwall/sdk/paywall/vc/PaywallViewController.kt
+++ b/superwall/src/main/java/com/superwall/sdk/paywall/vc/PaywallViewController.kt
@@ -1,8 +1,5 @@
 package com.superwall.sdk.paywall.vc
 
-import LogLevel
-import LogScope
-import Logger
 import android.Manifest
 import android.R
 import android.app.Activity
@@ -42,6 +39,9 @@ import com.superwall.sdk.dependencies.TriggerSessionManagerFactory
 import com.superwall.sdk.game.GameControllerDelegate
 import com.superwall.sdk.game.GameControllerEvent
 import com.superwall.sdk.game.GameControllerManager
+import com.superwall.sdk.logger.LogLevel
+import com.superwall.sdk.logger.LogScope
+import com.superwall.sdk.logger.Logger
 import com.superwall.sdk.misc.AlertControllerFactory
 import com.superwall.sdk.misc.isDarkColor
 import com.superwall.sdk.misc.isLightColor

--- a/superwall/src/main/java/com/superwall/sdk/paywall/vc/Survey/SurveyManager.kt
+++ b/superwall/src/main/java/com/superwall/sdk/paywall/vc/Survey/SurveyManager.kt
@@ -21,6 +21,9 @@ import com.superwall.sdk.config.models.Survey
 import com.superwall.sdk.config.models.SurveyOption
 import com.superwall.sdk.config.models.SurveyShowCondition
 import com.superwall.sdk.dependencies.TriggerFactory
+import com.superwall.sdk.logger.LogLevel
+import com.superwall.sdk.logger.LogScope
+import com.superwall.sdk.logger.Logger
 import com.superwall.sdk.models.paywall.PresentationCondition
 import com.superwall.sdk.paywall.presentation.PaywallCloseReason
 import com.superwall.sdk.paywall.presentation.PaywallInfo

--- a/superwall/src/main/java/com/superwall/sdk/paywall/vc/web_view/SWWebView.kt
+++ b/superwall/src/main/java/com/superwall/sdk/paywall/vc/web_view/SWWebView.kt
@@ -50,6 +50,7 @@ class SWWebView(
         webSettings.displayZoomControls = false
         webSettings.allowFileAccess = false
         webSettings.allowContentAccess = false
+        webSettings.textZoom = 100
 
         // Enable inline media playback, requires API level 17
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {

--- a/superwall/src/main/java/com/superwall/sdk/paywall/vc/web_view/messaging/PaywallMessageHandler.kt
+++ b/superwall/src/main/java/com/superwall/sdk/paywall/vc/web_view/messaging/PaywallMessageHandler.kt
@@ -1,8 +1,5 @@
 package com.superwall.sdk.paywall.vc.web_view.messaging
 
-import LogLevel
-import LogScope
-import Logger
 import TemplateLogic
 import android.util.Log
 import android.webkit.JavascriptInterface
@@ -12,6 +9,9 @@ import com.superwall.sdk.analytics.SessionEventsManager
 import com.superwall.sdk.analytics.internal.track
 import com.superwall.sdk.analytics.internal.trackable.InternalSuperwallEvent
 import com.superwall.sdk.dependencies.VariablesFactory
+import com.superwall.sdk.logger.LogLevel
+import com.superwall.sdk.logger.LogScope
+import com.superwall.sdk.logger.Logger
 import com.superwall.sdk.models.paywall.Paywall
 import com.superwall.sdk.paywall.presentation.PaywallInfo
 import com.superwall.sdk.paywall.presentation.internal.PresentationRequest

--- a/superwall/src/main/java/com/superwall/sdk/paywall/vc/web_view/messaging/RawWebMessageHandler.kt
+++ b/superwall/src/main/java/com/superwall/sdk/paywall/vc/web_view/messaging/RawWebMessageHandler.kt
@@ -1,10 +1,10 @@
 package com.superwall.sdk.paywall.vc.web_view.messaging
 
-import LogLevel
-import LogScope
-import Logger
 import android.webkit.JavascriptInterface
 import android.webkit.WebViewClient
+import com.superwall.sdk.logger.LogLevel
+import com.superwall.sdk.logger.LogScope
+import com.superwall.sdk.logger.Logger
 import com.superwall.sdk.paywall.vc.web_view.PaywallMessage
 import com.superwall.sdk.paywall.vc.web_view.parseWrappedPaywallMessages
 import kotlinx.coroutines.CoroutineScope

--- a/superwall/src/main/java/com/superwall/sdk/storage/Cache.kt
+++ b/superwall/src/main/java/com/superwall/sdk/storage/Cache.kt
@@ -1,8 +1,9 @@
 package com.superwall.sdk.storage
 
-import LogScope
-import Logger
 import android.content.Context
+import com.superwall.sdk.logger.LogLevel
+import com.superwall.sdk.logger.LogScope
+import com.superwall.sdk.logger.Logger
 import com.superwall.sdk.storage.memory.LRUCache
 import com.superwall.sdk.storage.memory.PerpetualCache
 import kotlinx.coroutines.ExecutorCoroutineDispatcher

--- a/superwall/src/main/java/com/superwall/sdk/storage/core_data/CoreDataManager.kt
+++ b/superwall/src/main/java/com/superwall/sdk/storage/core_data/CoreDataManager.kt
@@ -3,6 +3,9 @@ package com.superwall.sdk.storage.core_data
 import ComputedPropertyRequest
 import android.content.Context
 import android.icu.util.Calendar
+import com.superwall.sdk.logger.LogLevel
+import com.superwall.sdk.logger.LogScope
+import com.superwall.sdk.logger.Logger
 import com.superwall.sdk.models.events.EventData
 import com.superwall.sdk.models.triggers.TriggerRuleOccurrence
 import com.superwall.sdk.storage.core_data.entities.ManagedEventData

--- a/superwall/src/main/java/com/superwall/sdk/store/ExternalNativePurchaseController.kt
+++ b/superwall/src/main/java/com/superwall/sdk/store/ExternalNativePurchaseController.kt
@@ -70,7 +70,7 @@ class ExternalNativePurchaseController(var context: Context) : PurchaseControlle
         offerId: String?
     ): PurchaseResult {
         val offerToken = productDetails.subscriptionOfferDetails
-            ?.firstOrNull { it.offerId == offerId }
+            ?.firstOrNull { it.basePlanId == basePlanId && it.offerId == offerId }
             ?.offerToken
             ?: ""
 
@@ -156,7 +156,7 @@ class ExternalNativePurchaseController(var context: Context) : PurchaseControlle
         val hasActivePurchaseOrSubscription = allPurchases.any { it.purchaseState == Purchase.PurchaseState.PURCHASED }
         val status: SubscriptionStatus = if (hasActivePurchaseOrSubscription) SubscriptionStatus.ACTIVE else SubscriptionStatus.INACTIVE
 
-        if (Superwall.initialized == false) {
+        if (!Superwall.initialized) {
             Logger.debug(
                 logLevel = LogLevel.error,
                 scope = LogScope.nativePurchaseController,
@@ -165,7 +165,7 @@ class ExternalNativePurchaseController(var context: Context) : PurchaseControlle
             return
         }
 
-        Superwall.instance.setSubscriptionStatus(status)
+        Superwall.instance.setSubscriptionStatus(SubscriptionStatus.INACTIVE)
     }
 
     private suspend fun queryPurchasesOfType(productType: String): List<Purchase> {

--- a/superwall/src/main/java/com/superwall/sdk/store/ExternalNativePurchaseController.kt
+++ b/superwall/src/main/java/com/superwall/sdk/store/ExternalNativePurchaseController.kt
@@ -10,6 +10,9 @@ import com.superwall.sdk.delegate.PurchaseResult
 import com.superwall.sdk.delegate.RestorationResult
 import com.superwall.sdk.delegate.SubscriptionStatus
 import com.superwall.sdk.delegate.subscription_controller.PurchaseController
+import com.superwall.sdk.logger.LogLevel
+import com.superwall.sdk.logger.LogScope
+import com.superwall.sdk.logger.Logger
 import com.superwall.sdk.store.abstractions.product.OfferType
 import com.superwall.sdk.store.abstractions.product.RawStoreProduct
 import com.superwall.sdk.store.abstractions.product.StoreProduct

--- a/superwall/src/main/java/com/superwall/sdk/store/StoreKitManager.kt
+++ b/superwall/src/main/java/com/superwall/sdk/store/StoreKitManager.kt
@@ -1,13 +1,13 @@
 package com.superwall.sdk.store
 
-import LogLevel
-import LogScope
-import Logger
 import android.content.Context
 import com.superwall.sdk.Superwall
 import com.superwall.sdk.analytics.internal.track
 import com.superwall.sdk.analytics.internal.trackable.InternalSuperwallEvent
 import com.superwall.sdk.dependencies.TriggerSessionManagerFactory
+import com.superwall.sdk.logger.LogLevel
+import com.superwall.sdk.logger.LogScope
+import com.superwall.sdk.logger.Logger
 import com.superwall.sdk.models.paywall.Paywall
 import com.superwall.sdk.models.paywall.PaywallProducts
 import com.superwall.sdk.models.product.Product

--- a/superwall/src/main/java/com/superwall/sdk/store/abstractions/product/RawStoreProduct.kt
+++ b/superwall/src/main/java/com/superwall/sdk/store/abstractions/product/RawStoreProduct.kt
@@ -55,7 +55,6 @@ class RawStoreProduct(
             ?: selectedOffer.pricingPhases.pricingPhaseList
                 .dropLast(1)
                 .firstOrNull { it.priceAmountMicros != 0L }
-
     }
 
     override val productIdentifier by lazy {

--- a/superwall/src/main/java/com/superwall/sdk/store/abstractions/product/RawStoreProduct.kt
+++ b/superwall/src/main/java/com/superwall/sdk/store/abstractions/product/RawStoreProduct.kt
@@ -35,7 +35,7 @@ class RawStoreProduct(
         selectedOffer?.offerId
     }
 
-    private val selectedOffer: SubscriptionOfferDetails? by lazy {
+    val selectedOffer: SubscriptionOfferDetails? by lazy {
         getSelectedOfferDetails()
     }
 

--- a/superwall/src/main/java/com/superwall/sdk/store/abstractions/product/receipt/ReceiptManager.kt
+++ b/superwall/src/main/java/com/superwall/sdk/store/abstractions/product/receipt/ReceiptManager.kt
@@ -1,8 +1,8 @@
 package com.superwall.sdk.store.abstractions.product.receipt
 
-import LogLevel
-import LogScope
-import Logger
+import com.superwall.sdk.logger.LogLevel
+import com.superwall.sdk.logger.LogScope
+import com.superwall.sdk.logger.Logger
 import com.superwall.sdk.store.abstractions.product.StoreProduct
 import com.superwall.sdk.store.coordinator.ProductsFetcher
 import kotlinx.coroutines.*

--- a/superwall/src/main/java/com/superwall/sdk/store/transactions/TransactionManager.kt
+++ b/superwall/src/main/java/com/superwall/sdk/store/transactions/TransactionManager.kt
@@ -1,8 +1,5 @@
 package com.superwall.sdk.store.transactions
 
-import LogLevel
-import LogScope
-import Logger
 import android.content.Context
 import com.superwall.sdk.Superwall
 import com.superwall.sdk.analytics.SessionEventsManager
@@ -18,6 +15,9 @@ import com.superwall.sdk.dependencies.OptionsFactory
 import com.superwall.sdk.dependencies.StoreTransactionFactory
 import com.superwall.sdk.dependencies.TransactionVerifierFactory
 import com.superwall.sdk.dependencies.TriggerFactory
+import com.superwall.sdk.logger.LogLevel
+import com.superwall.sdk.logger.LogScope
+import com.superwall.sdk.logger.Logger
 import com.superwall.sdk.misc.ActivityProvider
 import com.superwall.sdk.models.paywall.LocalNotificationType
 import com.superwall.sdk.paywall.presentation.internal.dismiss

--- a/superwall/src/main/java/com/superwall/sdk/store/transactions/notifications/NotificationScheduler.kt
+++ b/superwall/src/main/java/com/superwall/sdk/store/transactions/notifications/NotificationScheduler.kt
@@ -1,11 +1,13 @@
 package com.superwall.sdk.store.transactions.notifications
 
-import Logger
 import android.content.Context
 import androidx.work.OneTimeWorkRequestBuilder
 import androidx.work.WorkManager
 import androidx.work.workDataOf
 import com.superwall.sdk.dependencies.DeviceHelperFactory
+import com.superwall.sdk.logger.LogLevel
+import com.superwall.sdk.logger.LogScope
+import com.superwall.sdk.logger.Logger
 import com.superwall.sdk.models.paywall.LocalNotification
 import com.superwall.sdk.paywall.vc.SuperwallPaywallActivity
 import java.util.concurrent.TimeUnit


### PR DESCRIPTION
The SDK is no longer in alpha! For those upgrading from the previous alpha, here's what's changed:

### Breaking Changes

- Changes the import path for the `LogScope`, and `LogLevel`.

### Fixes

- Fixes rare thread-safety crash when sending events back to Superwall's servers.
- Calls the `onError` presentation handler block when there's no activity to present a paywall on.
- Fixes issue where the wrong product may be presented to purchase if a free trial had already been 
used and you were letting Superwall handle purchases.
- Fixes `IllegalStateException` on Samsung devices when letting Superwall handle purchases.
- Keeps the text zoom of paywalls to 100% rather than respecting the accessibility settings text zoom,
which caused unexpected UI issues.
- Fixes rare `UninitializedPropertyAccessException` crash caused by a threading issue.
- Fixes crash when the user has disabled the Android System WebView.