### PR TITLE
Ensure implicit event tracking is always awaited

### DIFF
--- a/superwall/src/main/java/com/superwall/sdk/analytics/internal/Tracking.kt
+++ b/superwall/src/main/java/com/superwall/sdk/analytics/internal/Tracking.kt
@@ -21,11 +21,9 @@ import com.superwall.sdk.paywall.presentation.internal.state.PaywallState
 import com.superwall.sdk.paywall.presentation.result.PresentationResult
 import com.superwall.sdk.storage.DisableVerboseEvents
 import com.superwall.sdk.utilities.withErrorTracking
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withContext
 import java.util.Date
@@ -100,12 +98,10 @@ suspend fun Superwall.track(event: Trackable): Result<TrackingResult> {
         dependencyContainer.storage.coreDataManager.saveEventData(eventData)
 
         if (event.canImplicitlyTriggerPaywall) {
-            CoroutineScope(Dispatchers.IO).launch {
-                Superwall.instance.handleImplicitTrigger(
-                    event = event,
-                    eventData = eventData,
-                )
-            }
+            Superwall.instance.handleImplicitTrigger(
+                event = event,
+                eventData = eventData,
+            )
         }
 
         return@withErrorTracking TrackingResult(


### PR DESCRIPTION

## Changes in this pull request

- Ensure implicit event tracking is always awaited to prevent concurrency issues

### Checklist

- [ ] All unit tests pass.
- [ ] All UI tests pass.
- [ ] Demo project builds and runs.
- [ ] I added/updated tests or detailed why my change isn't tested.
- [ ] I added an entry to the `CHANGELOG.md` for any breaking changes, enhancements, or bug fixes.
- [ ] I have run `ktlint` in the main directory and fixed any issues.
- [ ] I have updated the SDK documentation as well as the online docs.
- [ ] I have reviewed the [contributing guide](https://github.com/superwall/Superwall-Android/tree/master/.github/CONTRIBUTING.md)