### PR TITLE
Fix one-time lifetime purchase entitlements not being discovered

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The changelog for `Superwall`. Also see the [releases](https://github.com/superwall/Superwall-Android/releases) on GitHub.
 
+
+## 2.5.8
+
+## Fixes
+- Fix lifetime purchase entitlements not being discovered in some cases on purchase
+
 ## 2.5.7
 
 ## Fixes

--- a/superwall/src/main/java/com/superwall/sdk/store/AutomaticPurchaseController.kt
+++ b/superwall/src/main/java/com/superwall/sdk/store/AutomaticPurchaseController.kt
@@ -262,12 +262,11 @@ class AutomaticPurchaseController(
         val subscriptionPurchases = queryPurchasesOfType(BillingClient.ProductType.SUBS)
         val inAppPurchases = queryPurchasesOfType(BillingClient.ProductType.INAPP)
         val allPurchases = subscriptionPurchases + inAppPurchases
-
         val hasActivePurchaseOrSubscription =
             allPurchases.any { it.purchaseState == Purchase.PurchaseState.PURCHASED }
         val status: SubscriptionStatus =
             if (hasActivePurchaseOrSubscription) {
-                subscriptionPurchases
+                allPurchases
                     .flatMap {
                         it.products
                     }.toSet()

--- a/superwall/src/main/java/com/superwall/sdk/store/Entitlements.kt
+++ b/superwall/src/main/java/com/superwall/sdk/store/Entitlements.kt
@@ -136,6 +136,7 @@ class Entitlements(
         val decomposedProductIds = DecomposedProductIds.from(id)
         listOf(
             decomposedProductIds.fullId,
+            "${decomposedProductIds.subscriptionId}:${decomposedProductIds.basePlanId}:${decomposedProductIds.offerType.id ?: ""}",
             "${decomposedProductIds.subscriptionId}:${decomposedProductIds.basePlanId}",
             decomposedProductIds.subscriptionId,
         ).forEach { id ->


### PR DESCRIPTION

## Changes in this pull request

## Fixes
- Fix lifetime purchase entitlements not being discovered in some cases on purchase
### Checklist

- [ ] All unit tests pass.
- [ ] All UI tests pass.
- [ ] Demo project builds and runs.
- [ ] I added/updated tests or detailed why my change isn't tested.
- [ ] I added an entry to the `CHANGELOG.md` for any breaking changes, enhancements, or bug fixes.
- [ ] I have run `ktlint` in the main directory and fixed any issues.
- [ ] I have updated the SDK documentation as well as the online docs.
- [ ] I have reviewed the [contributing guide](https://github.com/superwall/Superwall-Android/tree/master/.github/CONTRIBUTING.md)