### PR TITLE
Fix value normalization and animation issues

### DIFF
--- a/superwall/src/main/java/com/superwall/sdk/paywall/view/SuperwallPaywallActivity.kt
+++ b/superwall/src/main/java/com/superwall/sdk/paywall/view/SuperwallPaywallActivity.kt
@@ -520,8 +520,8 @@ class SuperwallPaywallActivity : AppCompatActivity() {
         val content = contentView as ViewGroup
         val bottomSheetBehavior = BottomSheetBehavior.from(content.getChildAt(0))
         if (!isModal) {
-            // halfExpandedRatio must be strictly between 0 and 1 (exclusive)
             val normalizedHeight = (if (height > 1.0) height / 100 else height).toFloat()
+            // Clamp to (0, 1) since 0.0 = STATE_COLLAPSED and 1.0 = STATE_EXPANDED
             bottomSheetBehavior.halfExpandedRatio = normalizedHeight.coerceIn(0.01f, 0.99f)
         } else {
             // If it's a Modal, we want it to cover only 95% of the screen when expanded


### PR DESCRIPTION
The BottomSheetBehavior.halfExpandedRatio requires a value strictly between 0 and 1 (exclusive). When the editor allows setting height to 100%, the calculation would yield 1.0, causing an IllegalArgumentException.

This fix clamps the ratio to the valid range (0.01 to 0.99).

## Changes in this pull request

-

### Checklist

- [ ] All unit tests pass.
- [ ] All UI tests pass.
- [ ] Demo project builds and runs.
- [ ] I added/updated tests or detailed why my change isn't tested.
- [ ] I added an entry to the `CHANGELOG.md` for any breaking changes, enhancements, or bug fixes.
- [ ] I have run `ktlint` in the main directory and fixed any issues.
- [ ] I have updated the SDK documentation as well as the online docs.
- [ ] I have reviewed the [contributing guide](https://github.com/superwall/Superwall-Android/tree/master/.github/CONTRIBUTING.md)