### PR TITLE
Add custom callbacks message and interface

### DIFF
--- a/superwall/src/main/java/com/superwall/sdk/Superwall.kt
+++ b/superwall/src/main/java/com/superwall/sdk/Superwall.kt
@@ -1417,6 +1417,14 @@ class Superwall(
                         message = "Permission requested: ${paywallEvent.permissionType.rawValue}",
                     )
                 }
+
+                is PaywallWebEvent.RequestCallback -> {
+                    Logger.debug(
+                        LogLevel.debug,
+                        LogScope.paywallView,
+                        message = "Custom callback requested: ${paywallEvent.name}",
+                    )
+                }
             }
         }
     }

--- a/superwall/src/main/java/com/superwall/sdk/dependencies/DependencyContainer.kt
+++ b/superwall/src/main/java/com/superwall/sdk/dependencies/DependencyContainer.kt
@@ -66,6 +66,7 @@ import com.superwall.sdk.network.device.DeviceInfo
 import com.superwall.sdk.network.session.CustomHttpUrlConnection
 import com.superwall.sdk.paywall.manager.PaywallManager
 import com.superwall.sdk.paywall.manager.PaywallViewCache
+import com.superwall.sdk.paywall.presentation.CustomCallbackRegistry
 import com.superwall.sdk.paywall.presentation.PaywallInfo
 import com.superwall.sdk.paywall.presentation.dismiss
 import com.superwall.sdk.paywall.presentation.get_presentation_result.internallyGetPresentationResult
@@ -190,6 +191,7 @@ class DependencyContainer(
     val googleBillingWrapper: GoogleBillingWrapper
     internal val reviewManager: ReviewManager
     internal val userPermissions: UserPermissions
+    internal val customCallbackRegistry: CustomCallbackRegistry
 
     var entitlements: Entitlements
     internal lateinit var customerInfoManager: CustomerInfoManager
@@ -597,6 +599,7 @@ class DependencyContainer(
             }
 
         userPermissions = UserPermissionsImpl(context)
+        customCallbackRegistry = CustomCallbackRegistry()
 
         deepLinkRouter =
             DeepLinkRouter(
@@ -709,6 +712,7 @@ class DependencyContainer(
                 },
                 userPermissions = userPermissions,
                 getActivity = { activityProvider?.getCurrentActivity() },
+                customCallbackRegistry = customCallbackRegistry,
             )
 
         val state =

--- a/superwall/src/main/java/com/superwall/sdk/paywall/presentation/CustomCallback.kt
+++ b/superwall/src/main/java/com/superwall/sdk/paywall/presentation/CustomCallback.kt
@@ -1,0 +1,72 @@
+package com.superwall.sdk.paywall.presentation
+
+/**
+ * Defines how the paywall waits for a custom callback response.
+ */
+enum class CustomCallbackBehavior(
+    val rawValue: String,
+) {
+    /**
+     * The paywall waits for the callback to complete before continuing
+     * the tap action chain.
+     */
+    BLOCKING("blocking"),
+
+    /**
+     * The paywall continues immediately; the response still triggers
+     * onSuccess/onFailure handlers in the paywall.
+     */
+    NON_BLOCKING("non-blocking"),
+    ;
+
+    companion object {
+        fun fromRaw(rawValue: String): CustomCallbackBehavior? = entries.find { it.rawValue == rawValue }
+    }
+}
+
+/**
+ * Represents a custom callback request from the paywall.
+ *
+ * @property name The name of the callback being requested.
+ * @property variables Optional key-value pairs passed from the paywall.
+ *                     Values are type-preserved (string/number/boolean).
+ */
+data class CustomCallback(
+    val name: String,
+    val variables: Map<String, Any>?,
+)
+
+/**
+ * The result status of a custom callback.
+ */
+enum class CustomCallbackResultStatus(
+    val rawValue: String,
+) {
+    SUCCESS("success"),
+    FAILURE("failure"),
+}
+
+/**
+ * The result to return from a custom callback handler.
+ *
+ * @property status Whether the callback succeeded or failed.
+ *                  Determines which branch (onSuccess/onFailure) executes in the paywall.
+ * @property data Optional key-value pairs to return to the paywall.
+ *               Values are type-preserved and accessible as callbacks.<name>.data.<key>.
+ */
+data class CustomCallbackResult(
+    val status: CustomCallbackResultStatus,
+    val data: Map<String, Any>? = null,
+) {
+    companion object {
+        /**
+         * Creates a success result with optional data.
+         */
+        fun success(data: Map<String, Any>? = null): CustomCallbackResult = CustomCallbackResult(CustomCallbackResultStatus.SUCCESS, data)
+
+        /**
+         * Creates a failure result with optional data.
+         */
+        fun failure(data: Map<String, Any>? = null): CustomCallbackResult = CustomCallbackResult(CustomCallbackResultStatus.FAILURE, data)
+    }
+}

--- a/superwall/src/main/java/com/superwall/sdk/paywall/presentation/CustomCallbackRegistry.kt
+++ b/superwall/src/main/java/com/superwall/sdk/paywall/presentation/CustomCallbackRegistry.kt
@@ -1,0 +1,51 @@
+package com.superwall.sdk.paywall.presentation
+
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * Registry for custom callback handlers associated with paywall presentations.
+ *
+ * Handlers are stored by paywall identifier and should be cleaned up when
+ * the paywall is dismissed to prevent memory leaks.
+ */
+class CustomCallbackRegistry {
+    private val handlers = ConcurrentHashMap<String, suspend (CustomCallback) -> CustomCallbackResult>()
+
+    /**
+     * Registers a custom callback handler for a paywall.
+     *
+     * @param paywallIdentifier The unique identifier of the paywall
+     * @param handler The callback handler to register
+     */
+    fun register(
+        paywallIdentifier: String,
+        handler: suspend (CustomCallback) -> CustomCallbackResult,
+    ) {
+        handlers[paywallIdentifier] = handler
+    }
+
+    /**
+     * Unregisters the custom callback handler for a paywall.
+     * Should be called when the paywall is dismissed.
+     *
+     * @param paywallIdentifier The unique identifier of the paywall
+     */
+    fun unregister(paywallIdentifier: String) {
+        handlers.remove(paywallIdentifier)
+    }
+
+    /**
+     * Gets the custom callback handler for a paywall, if registered.
+     *
+     * @param paywallIdentifier The unique identifier of the paywall
+     * @return The handler, or null if not registered
+     */
+    fun getHandler(paywallIdentifier: String): (suspend (CustomCallback) -> CustomCallbackResult)? = handlers[paywallIdentifier]
+
+    /**
+     * Clears all registered handlers.
+     */
+    fun clear() {
+        handlers.clear()
+    }
+}

--- a/superwall/src/main/java/com/superwall/sdk/paywall/presentation/PaywallPresentationHandler.kt
+++ b/superwall/src/main/java/com/superwall/sdk/paywall/presentation/PaywallPresentationHandler.kt
@@ -16,6 +16,9 @@ class PaywallPresentationHandler {
     // A block called when a paywall is skipped, but no error has occurred
     internal var onSkipHandler: ((PaywallSkippedReason) -> Unit)? = null
 
+    // A block called when the paywall requests a custom callback
+    internal var onCustomCallbackHandler: (suspend (CustomCallback) -> CustomCallbackResult)? = null
+
     // Sets the handler that will be called when the paywall did present
     fun onPresent(handler: (PaywallInfo) -> Unit) {
         onPresentHandler = handler
@@ -34,5 +37,36 @@ class PaywallPresentationHandler {
     // Sets the handler that will be called when a paywall is skipped, but no error has occurred
     fun onSkip(handler: (PaywallSkippedReason) -> Unit) {
         onSkipHandler = handler
+    }
+
+    /**
+     * Sets the handler that will be called when the paywall requests a custom callback.
+     *
+     * Custom callbacks allow paywalls to request arbitrary actions from the app and
+     * receive results that determine which branch (onSuccess/onFailure) executes.
+     *
+     * @param handler A function that receives a [CustomCallback] containing the callback
+     *                name and optional variables, and returns a [CustomCallbackResult]
+     *                indicating success/failure with optional data.
+     *
+     * Example:
+     * ```
+     * handler.onCustomCallback { callback ->
+     *     when (callback.name) {
+     *         "validate_email" -> {
+     *             val email = callback.variables?.get("email") as? String
+     *             if (isValidEmail(email)) {
+     *                 CustomCallbackResult.success(mapOf("validated" to true))
+     *             } else {
+     *                 CustomCallbackResult.failure(mapOf("error" to "Invalid email"))
+     *             }
+     *         }
+     *         else -> CustomCallbackResult.failure()
+     *     }
+     * }
+     * ```
+     */
+    fun onCustomCallback(handler: suspend (CustomCallback) -> CustomCallbackResult) {
+        onCustomCallbackHandler = handler
     }
 }

--- a/superwall/src/main/java/com/superwall/sdk/paywall/view/webview/messaging/PaywallMessageHandler.kt
+++ b/superwall/src/main/java/com/superwall/sdk/paywall/view/webview/messaging/PaywallMessageHandler.kt
@@ -14,6 +14,10 @@ import com.superwall.sdk.logger.Logger
 import com.superwall.sdk.misc.MainScope
 import com.superwall.sdk.models.paywall.LocalNotification
 import com.superwall.sdk.models.paywall.Paywall
+import com.superwall.sdk.paywall.presentation.CustomCallback
+import com.superwall.sdk.paywall.presentation.CustomCallbackRegistry
+import com.superwall.sdk.paywall.presentation.CustomCallbackResult
+import com.superwall.sdk.paywall.presentation.CustomCallbackResultStatus
 import com.superwall.sdk.paywall.view.PaywallView
 import com.superwall.sdk.paywall.view.PaywallViewState
 import com.superwall.sdk.paywall.view.delegate.PaywallLoadingState
@@ -68,6 +72,7 @@ class PaywallMessageHandler(
     private val encodeToB64: (String) -> String,
     private val userPermissions: UserPermissions,
     private val getActivity: () -> Activity?,
+    private val customCallbackRegistry: CustomCallbackRegistry,
 ) : SendPaywallMessages {
     private companion object {
         val selectionString =
@@ -232,6 +237,8 @@ class PaywallMessageHandler(
                 )
 
             is PaywallMessage.RequestPermission -> handleRequestPermission(message)
+
+            is PaywallMessage.RequestCallback -> handleRequestCallback(message)
 
             else -> {
                 Logger.debug(
@@ -613,6 +620,113 @@ class PaywallMessageHandler(
             LogLevel.debug,
             LogScope.superwallCore,
             "Sending permission_result: $jsonString",
+        )
+
+        passMessageToWebView(base64String = encodeToB64(jsonString))
+    }
+
+    private fun handleRequestCallback(request: PaywallMessage.RequestCallback) {
+        val paywallIdentifier = messageHandler?.state?.paywall?.identifier ?: ""
+
+        // Emit event to listeners
+        messageHandler?.eventDidOccur(
+            PaywallWebEvent.RequestCallback(
+                name = request.name,
+                behavior = request.behavior,
+                requestId = request.requestId,
+                variables = request.variables,
+            ),
+        )
+
+        // Get the callback handler from the registry
+        val callbackHandler = customCallbackRegistry.getHandler(paywallIdentifier)
+
+        if (callbackHandler == null) {
+            Logger.debug(
+                LogLevel.warn,
+                LogScope.superwallCore,
+                "No custom callback handler registered for callback: ${request.name}",
+            )
+            // Send failure response if no handler is registered
+            ioScope.launch {
+                sendCallbackResult(
+                    requestId = request.requestId,
+                    name = request.name,
+                    status = CustomCallbackResultStatus.FAILURE,
+                    data = null,
+                )
+            }
+            return
+        }
+
+        ioScope.launch {
+            val result =
+                try {
+                    val callback =
+                        CustomCallback(
+                            name = request.name,
+                            variables = request.variables,
+                        )
+                    callbackHandler(callback)
+                } catch (e: Exception) {
+                    Logger.debug(
+                        LogLevel.error,
+                        LogScope.superwallCore,
+                        "Error executing custom callback: ${e.message}",
+                        error = e,
+                    )
+                    CustomCallbackResult.failure()
+                }
+
+            sendCallbackResult(
+                requestId = request.requestId,
+                name = request.name,
+                status = result.status,
+                data = result.data,
+            )
+        }
+    }
+
+    /**
+     * Send a callback_result message back to the webview
+     */
+    private suspend fun sendCallbackResult(
+        requestId: String,
+        name: String,
+        status: CustomCallbackResultStatus,
+        data: Map<String, Any>?,
+    ) {
+        val eventMap =
+            mutableMapOf<String, Any>(
+                "event_name" to "callback_result",
+                "request_id" to requestId,
+                "name" to name,
+                "status" to status.rawValue,
+            )
+
+        if (data != null) {
+            eventMap["data"] = data
+        }
+
+        val eventList = listOf(eventMap)
+
+        val jsonString =
+            try {
+                json.encodeToString(eventList.convertToJsonElement())
+            } catch (e: Throwable) {
+                Logger.debug(
+                    LogLevel.error,
+                    LogScope.superwallCore,
+                    "Error encoding callback result: ${e.message}",
+                    error = e,
+                )
+                return
+            }
+
+        Logger.debug(
+            LogLevel.debug,
+            LogScope.superwallCore,
+            "Sending callback_result: $jsonString",
         )
 
         passMessageToWebView(base64String = encodeToB64(jsonString))

--- a/superwall/src/main/java/com/superwall/sdk/paywall/view/webview/messaging/PaywallWebEvent.kt
+++ b/superwall/src/main/java/com/superwall/sdk/paywall/view/webview/messaging/PaywallWebEvent.kt
@@ -2,6 +2,7 @@ package com.superwall.sdk.paywall.view.webview.messaging
 
 import android.net.Uri
 import com.superwall.sdk.models.paywall.LocalNotification
+import com.superwall.sdk.paywall.presentation.CustomCallbackBehavior
 import com.superwall.sdk.permissions.PermissionType
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
@@ -69,5 +70,13 @@ sealed class PaywallWebEvent {
     data class RequestPermission(
         val permissionType: PermissionType,
         val requestId: String,
+    ) : PaywallWebEvent()
+
+    @SerialName("request_callback")
+    data class RequestCallback(
+        val name: String,
+        val behavior: CustomCallbackBehavior,
+        val requestId: String,
+        val variables: Map<String, Any>?,
     ) : PaywallWebEvent()
 }

--- a/superwall/src/test/java/com/superwall/sdk/paywall/presentation/CustomCallbackRegistryTest.kt
+++ b/superwall/src/test/java/com/superwall/sdk/paywall/presentation/CustomCallbackRegistryTest.kt
@@ -1,0 +1,241 @@
+package com.superwall.sdk.paywall.presentation
+
+import com.superwall.sdk.Given
+import com.superwall.sdk.Then
+import com.superwall.sdk.When
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Test
+
+class CustomCallbackRegistryTest {
+    private lateinit var registry: CustomCallbackRegistry
+
+    @Before
+    fun setUp() {
+        registry = CustomCallbackRegistry()
+    }
+
+    @Test
+    fun register_stores_handler_correctly() =
+        runTest {
+            Given("a CustomCallbackRegistry") {
+                val handlerInvocations = mutableListOf<CustomCallback>()
+                val handler: suspend (CustomCallback) -> CustomCallbackResult = { callback ->
+                    handlerInvocations.add(callback)
+                    CustomCallbackResult.success()
+                }
+
+                When("a handler is registered for a paywall identifier") {
+                    registry.register("paywall_123", handler)
+
+                    Then("the handler can be retrieved") {
+                        val retrieved = registry.getHandler("paywall_123")
+                        assertNotNull(retrieved)
+                    }
+                }
+            }
+        }
+
+    @Test
+    fun getHandler_returns_null_for_unregistered_paywall() =
+        runTest {
+            Given("a CustomCallbackRegistry with no handlers") {
+                When("getting a handler for an unregistered paywall") {
+                    val result = registry.getHandler("unknown_paywall")
+
+                    Then("it returns null") {
+                        assertNull(result)
+                    }
+                }
+            }
+        }
+
+    @Test
+    fun unregister_removes_handler() =
+        runTest {
+            Given("a registry with a registered handler") {
+                val handler: suspend (CustomCallback) -> CustomCallbackResult = {
+                    CustomCallbackResult.success()
+                }
+                registry.register("paywall_456", handler)
+
+                When("the handler is unregistered") {
+                    registry.unregister("paywall_456")
+
+                    Then("getHandler returns null for that paywall") {
+                        assertNull(registry.getHandler("paywall_456"))
+                    }
+                }
+            }
+        }
+
+    @Test
+    fun unregister_does_not_affect_other_handlers() =
+        runTest {
+            Given("a registry with multiple handlers") {
+                val handler1: suspend (CustomCallback) -> CustomCallbackResult = {
+                    CustomCallbackResult.success(mapOf("source" to "handler1"))
+                }
+                val handler2: suspend (CustomCallback) -> CustomCallbackResult = {
+                    CustomCallbackResult.success(mapOf("source" to "handler2"))
+                }
+                registry.register("paywall_1", handler1)
+                registry.register("paywall_2", handler2)
+
+                When("one handler is unregistered") {
+                    registry.unregister("paywall_1")
+
+                    Then("the other handler is still available") {
+                        assertNull(registry.getHandler("paywall_1"))
+                        assertNotNull(registry.getHandler("paywall_2"))
+                    }
+                }
+            }
+        }
+
+    @Test
+    fun clear_removes_all_handlers() =
+        runTest {
+            Given("a registry with multiple handlers") {
+                val handler: suspend (CustomCallback) -> CustomCallbackResult = {
+                    CustomCallbackResult.success()
+                }
+                registry.register("paywall_a", handler)
+                registry.register("paywall_b", handler)
+                registry.register("paywall_c", handler)
+
+                When("clear is called") {
+                    registry.clear()
+
+                    Then("all handlers are removed") {
+                        assertNull(registry.getHandler("paywall_a"))
+                        assertNull(registry.getHandler("paywall_b"))
+                        assertNull(registry.getHandler("paywall_c"))
+                    }
+                }
+            }
+        }
+
+    @Test
+    fun register_overwrites_existing_handler() =
+        runTest {
+            Given("a registry with an existing handler") {
+                var firstHandlerCalled = false
+                var secondHandlerCalled = false
+
+                val firstHandler: suspend (CustomCallback) -> CustomCallbackResult = {
+                    firstHandlerCalled = true
+                    CustomCallbackResult.success(mapOf("handler" to "first"))
+                }
+                val secondHandler: suspend (CustomCallback) -> CustomCallbackResult = {
+                    secondHandlerCalled = true
+                    CustomCallbackResult.success(mapOf("handler" to "second"))
+                }
+
+                registry.register("paywall_x", firstHandler)
+
+                When("a new handler is registered for the same paywall") {
+                    registry.register("paywall_x", secondHandler)
+
+                    Then("the new handler replaces the old one") {
+                        val retrieved = registry.getHandler("paywall_x")
+                        assertNotNull(retrieved)
+
+                        val callback = CustomCallback(name = "test", variables = null)
+                        val result = retrieved!!.invoke(callback)
+
+                        assertEquals(false, firstHandlerCalled)
+                        assertEquals(true, secondHandlerCalled)
+                        assertEquals("second", result.data?.get("handler"))
+                    }
+                }
+            }
+        }
+
+    @Test
+    fun registered_handler_receives_correct_callback_data() =
+        runTest {
+            Given("a registry with a handler that captures callback data") {
+                var capturedCallback: CustomCallback? = null
+
+                val handler: suspend (CustomCallback) -> CustomCallbackResult = { callback ->
+                    capturedCallback = callback
+                    CustomCallbackResult.success()
+                }
+                registry.register("paywall_capture", handler)
+
+                When("the handler is invoked with callback data") {
+                    val callback =
+                        CustomCallback(
+                            name = "validate_email",
+                            variables = mapOf("email" to "test@example.com", "count" to 42),
+                        )
+
+                    val retrieved = registry.getHandler("paywall_capture")
+                    retrieved!!.invoke(callback)
+
+                    Then("the handler receives the correct callback data") {
+                        assertNotNull(capturedCallback)
+                        assertEquals("validate_email", capturedCallback!!.name)
+                        assertEquals("test@example.com", capturedCallback!!.variables?.get("email"))
+                        assertEquals(42, capturedCallback!!.variables?.get("count"))
+                    }
+                }
+            }
+        }
+
+    @Test
+    fun handler_can_return_success_with_data() =
+        runTest {
+            Given("a handler that returns success with data") {
+                val handler: suspend (CustomCallback) -> CustomCallbackResult = {
+                    CustomCallbackResult.success(
+                        mapOf(
+                            "validated" to true,
+                            "score" to 100,
+                        ),
+                    )
+                }
+                registry.register("paywall_success", handler)
+
+                When("the handler is invoked") {
+                    val callback = CustomCallback(name = "test", variables = null)
+                    val retrieved = registry.getHandler("paywall_success")
+                    val result = retrieved!!.invoke(callback)
+
+                    Then("it returns success status with the data") {
+                        assertEquals(CustomCallbackResultStatus.SUCCESS, result.status)
+                        assertEquals(true, result.data?.get("validated"))
+                        assertEquals(100, result.data?.get("score"))
+                    }
+                }
+            }
+        }
+
+    @Test
+    fun handler_can_return_failure_with_data() =
+        runTest {
+            Given("a handler that returns failure with error data") {
+                val handler: suspend (CustomCallback) -> CustomCallbackResult = {
+                    CustomCallbackResult.failure(
+                        mapOf("error" to "Invalid input"),
+                    )
+                }
+                registry.register("paywall_failure", handler)
+
+                When("the handler is invoked") {
+                    val callback = CustomCallback(name = "test", variables = null)
+                    val retrieved = registry.getHandler("paywall_failure")
+                    val result = retrieved!!.invoke(callback)
+
+                    Then("it returns failure status with error data") {
+                        assertEquals(CustomCallbackResultStatus.FAILURE, result.status)
+                        assertEquals("Invalid input", result.data?.get("error"))
+                    }
+                }
+            }
+        }
+}

--- a/superwall/src/test/java/com/superwall/sdk/paywall/view/PaywallMessageHandlerTest.kt
+++ b/superwall/src/test/java/com/superwall/sdk/paywall/view/PaywallMessageHandlerTest.kt
@@ -311,6 +311,9 @@ class PaywallMessageHandlerTest {
                 encodeToB64 = { it },
                 userPermissions = fakeUserPermissions,
                 getActivity = { null },
+                customCallbackRegistry =
+                    com.superwall.sdk.paywall.presentation
+                        .CustomCallbackRegistry(),
             )
 
         val state =

--- a/superwall/src/test/java/com/superwall/sdk/paywall/view/PaywallViewTest.kt
+++ b/superwall/src/test/java/com/superwall/sdk/paywall/view/PaywallViewTest.kt
@@ -448,6 +448,9 @@ class PaywallViewTest {
                 encodeToB64 = { it },
                 userPermissions = fakeUserPermissions,
                 getActivity = { null },
+                customCallbackRegistry =
+                    com.superwall.sdk.paywall.presentation
+                        .CustomCallbackRegistry(),
             )
 
         val state =

--- a/superwall/src/test/java/com/superwall/sdk/paywall/view/webview/PaywallMessageHandlerTest.kt
+++ b/superwall/src/test/java/com/superwall/sdk/paywall/view/webview/PaywallMessageHandlerTest.kt
@@ -120,6 +120,9 @@ class PaywallMessageHandlerTest {
             encodeToB64 = encodeToB64,
             userPermissions = FakeUserPermissions(),
             getActivity = { null },
+            customCallbackRegistry =
+                com.superwall.sdk.paywall.presentation
+                    .CustomCallbackRegistry(),
         )
 
     @Test


### PR DESCRIPTION
## Changes in this pull request

- Enable custom callbacks from paywall to the app
- Adds a new method to `PaywallPresentationHandler` called `onCustomCallback` that allows user to handle custom callback requests 

### Checklist

- [ ] All unit tests pass.
- [ ] All UI tests pass.
- [ ] Demo project builds and runs.
- [ ] I added/updated tests or detailed why my change isn't tested.
- [ ] I added an entry to the `CHANGELOG.md` for any breaking changes, enhancements, or bug fixes.
- [ ] I have run `ktlint` in the main directory and fixed any issues.
- [ ] I have updated the SDK documentation as well as the online docs.
- [ ] I have reviewed the [contributing guide](https://github.com/superwall/Superwall-Android/tree/master/.github/CONTRIBUTING.md)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


Adds custom callback support enabling bidirectional communication between paywalls and app code.

- Added new `CustomCallback`, `CustomCallbackBehavior`, and `CustomCallbackResult` data classes to represent callback requests and responses
- Implemented `CustomCallbackRegistry` using `ConcurrentHashMap` for thread-safe handler storage with proper lifecycle management (registration on present, cleanup on dismiss)
- Added `onCustomCallback` method to `PaywallPresentationHandler` as the public API for apps to handle custom callback requests
- Integrated callback message parsing (`request_callback`) and response sending (`callback_result`) in `PaywallMessageHandler`
- Properly wired callbacks through the dependency injection system and paywall lifecycle
- Comprehensive test coverage including unit tests for registry operations and integration tests for message handling edge cases
- Exception handling ensures failures return appropriate error responses to the webview

<h3>Confidence Score: 5/5</h3>


- Safe to merge with no identified issues
- Implementation follows SDK patterns with proper thread safety, error handling, lifecycle management, and comprehensive test coverage. No logic errors or security concerns identified.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| superwall/src/main/java/com/superwall/sdk/paywall/presentation/CustomCallback.kt | Added data classes and enums for custom callback system with clear documentation |
| superwall/src/main/java/com/superwall/sdk/paywall/presentation/CustomCallbackRegistry.kt | Added thread-safe registry using ConcurrentHashMap with proper lifecycle management |
| superwall/src/main/java/com/superwall/sdk/paywall/presentation/PaywallPresentationHandler.kt | Added public API method with comprehensive documentation and usage examples |
| superwall/src/main/java/com/superwall/sdk/paywall/presentation/PublicPresentation.kt | Integrated callback registration/unregistration into paywall lifecycle correctly |
| superwall/src/main/java/com/superwall/sdk/paywall/view/webview/messaging/PaywallMessageHandler.kt | Implemented callback handling with proper error handling and async execution |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant App as App Code
    participant Handler as PaywallPresentationHandler
    participant Registry as CustomCallbackRegistry
    participant Superwall as Superwall
    participant WebView as PaywallView/WebView
    participant MsgHandler as PaywallMessageHandler
    
    Note over App,Handler: Registration Phase
    App->>Handler: register(event, handler)
    App->>Handler: handler.onCustomCallback { callback -> ... }
    Handler->>Handler: Store onCustomCallbackHandler
    
    Note over Superwall,Registry: Presentation Phase
    Superwall->>Registry: register(paywallId, handler)
    Superwall->>WebView: Present Paywall
    
    Note over WebView,MsgHandler: Callback Request
    WebView->>MsgHandler: postMessage("request_callback")
    MsgHandler->>MsgHandler: Parse PaywallMessage.RequestCallback
    MsgHandler->>Superwall: eventDidOccur(RequestCallback)
    
    Note over MsgHandler,Registry: Handler Execution
    MsgHandler->>Registry: getHandler(paywallId)
    Registry-->>MsgHandler: Return handler or null
    
    alt Handler exists
        MsgHandler->>App: Invoke handler(CustomCallback)
        App-->>MsgHandler: Return CustomCallbackResult
        MsgHandler->>WebView: sendCallbackResult(success/failure)
    else No handler
        MsgHandler->>WebView: sendCallbackResult(failure)
    end
    
    Note over Superwall,Registry: Dismissal Phase
    WebView->>Superwall: Paywall Dismissed
    Superwall->>Registry: unregister(paywallId)
    Registry->>Registry: Remove handler
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->