### PR TITLE
Remove timeout event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The changelog for `Superwall`. Also see the [releases](https://github.com/superwall/Superwall-Android/releases) on GitHub.
 
+
+## 2.6.9
+
+## Deprecations
+- Deprecated `paywallWebviewLoad_timeout` - this event was causing confusion due to it's naming, leading to it being deprecated
+
 ## 2.6.8
 
 ### Enhancements

--- a/superwall/src/main/java/com/superwall/sdk/analytics/internal/trackable/TrackableSuperwallEvent.kt
+++ b/superwall/src/main/java/com/superwall/sdk/analytics/internal/trackable/TrackableSuperwallEvent.kt
@@ -712,10 +712,6 @@ sealed class InternalSuperwallEvent(
 
             object Fallback : State()
 
-            class Timeout(
-                val msg: String,
-            ) : State()
-
             class Complete : State()
         }
 
@@ -724,11 +720,6 @@ sealed class InternalSuperwallEvent(
                 when (state) {
                     is PaywallWebviewLoad.State.Start ->
                         SuperwallEvent.PaywallWebviewLoadStart(
-                            paywallInfo,
-                        )
-
-                    is PaywallWebviewLoad.State.Timeout ->
-                        SuperwallEvent.PaywallWebviewLoadTimeout(
                             paywallInfo,
                         )
 
@@ -763,11 +754,6 @@ sealed class InternalSuperwallEvent(
                                 .mapIndexed { i, it ->
                                     "url_$i" to it
                                 }.toTypedArray(),
-                        )
-
-                    is State.Timeout ->
-                        mapOf(
-                            "error_message" to state.msg,
                         )
 
                     else -> mapOf()

--- a/superwall/src/main/java/com/superwall/sdk/analytics/superwall/SuperwallEvent.kt
+++ b/superwall/src/main/java/com/superwall/sdk/analytics/superwall/SuperwallEvent.kt
@@ -327,7 +327,7 @@ sealed class SuperwallEvent {
             get() = "paywallWebviewLoad_complete"
     }
 
-    // / When the loading of a paywall's website times out.
+    @Deprecated("Due to confusion this event was causing we're deprecating it's usage")
     data class PaywallWebviewLoadTimeout(
         val paywallInfo: PaywallInfo,
     ) : SuperwallEvent() {

--- a/superwall/src/main/java/com/superwall/sdk/analytics/superwall/SuperwallEvents.kt
+++ b/superwall/src/main/java/com/superwall/sdk/analytics/superwall/SuperwallEvents.kt
@@ -34,6 +34,8 @@ enum class SuperwallEvents(
     PaywallWebviewLoadStart("paywallWebviewLoad_start"),
     PaywallWebviewLoadFail("paywallWebviewLoad_fail"),
     PaywallWebviewLoadComplete("paywallWebviewLoad_complete"),
+
+    @Deprecated("Due to confusion this event was causing we're deprecating it's usage")
     PaywallWebviewLoadTimeout("paywallWebviewLoad_timeout"),
     PaywallWebviewLoadFallback("paywallWebviewLoad_fallback"),
     PaywallResourceLoadFail("paywallResourceLoad_fail"),

--- a/superwall/src/test/java/com/superwall/sdk/analytics/internal/TrackingLogicTest.kt
+++ b/superwall/src/test/java/com/superwall/sdk/analytics/internal/TrackingLogicTest.kt
@@ -436,30 +436,6 @@ class TrackingLogicTest {
             }
         }
 
-    @Test
-    fun `isNotDisabledVerboseEvent allows PaywallWebviewLoad Timeout even when verbose events disabled`() =
-        Given("PaywallWebviewLoad with Timeout state and verbose events disabled") {
-            val paywallInfo = PaywallInfo.empty()
-            val event =
-                InternalSuperwallEvent.PaywallWebviewLoad(
-                    state = InternalSuperwallEvent.PaywallWebviewLoad.State.Timeout("timeout"),
-                    paywallInfo = paywallInfo,
-                )
-
-            When("checking if event is not disabled verbose event") {
-                val result =
-                    TrackingLogic.isNotDisabledVerboseEvent(
-                        event,
-                        disableVerboseEvents = true,
-                        isSandbox = false,
-                    )
-
-                Then("it should return true because Timeout events are always allowed") {
-                    assertTrue(result)
-                }
-            }
-        }
-
     // ========== canTriggerPaywall Tests ==========
 
     @Test


### PR DESCRIPTION
## Changes in this pull request

- Deprecated `paywallWebviewLoad_timeout` - this event was causing confusion due to it's naming, leading to it being deprecated

### Checklist

- [ ] All unit tests pass.
- [ ] All UI tests pass.
- [ ] Demo project builds and runs.
- [ ] I added/updated tests or detailed why my change isn't tested.
- [ ] I added an entry to the `CHANGELOG.md` for any breaking changes, enhancements, or bug fixes.
- [ ] I have run `ktlint` in the main directory and fixed any issues.
- [ ] I have updated the SDK documentation as well as the online docs.
- [ ] I have reviewed the [contributing guide](https://github.com/superwall/Superwall-Android/tree/master/.github/CONTRIBUTING.md)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


Deprecated the `paywallWebviewLoad_timeout` event by removing its internal state representation and marking the public event class as deprecated. Timeout scenarios now emit `PaywallWebviewLoadFail` events with `WebviewError.Timeout` instead of a separate timeout event.

**Key Changes:**
- Removed `PaywallWebviewLoad.State.Timeout` class and its mapping logic
- Added `@Deprecated` annotations to `PaywallWebviewLoadTimeout` event classes
- Removed test case validating timeout event handling
- Updated CHANGELOG.md with deprecation notice for version 2.6.9

**Impact:**
The timeout scenario still functions correctly - when a paywall load times out, it now triggers a fail event rather than a distinct timeout event. This simplifies the event model while maintaining the same error handling behavior in `PaywallView.kt:316`.

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with minimal risk
- The changes are well-contained, maintain backward compatibility through deprecation annotations, and properly clean up related code including tests. The timeout functionality still works correctly by mapping to fail events.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| superwall/src/main/java/com/superwall/sdk/analytics/internal/trackable/TrackableSuperwallEvent.kt | Removed `State.Timeout` class and its mapping logic from `PaywallWebviewLoad` event |
| superwall/src/main/java/com/superwall/sdk/analytics/superwall/SuperwallEvent.kt | Added `@Deprecated` annotation to `PaywallWebviewLoadTimeout` event class |
| superwall/src/test/java/com/superwall/sdk/analytics/internal/TrackingLogicTest.kt | Removed test case for `PaywallWebviewLoad.State.Timeout` event handling |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant PV as PaywallView
    participant WV as WebView
    participant TE as TrackableSuperwallEvent
    participant SE as SuperwallEvent
    
    Note over PV,SE: Before: Timeout Event Flow
    PV->>PV: timeout detected
    PV->>TE: PaywallWebviewLoad(State.Timeout)
    TE->>SE: PaywallWebviewLoadTimeout
    SE-->>PV: timeout event tracked
    
    Note over PV,SE: After: Timeout Now Treated as Fail
    PV->>PV: timeout detected
    PV->>TE: PaywallWebviewLoad(State.Fail(WebviewError.Timeout))
    TE->>SE: PaywallWebviewLoadFail
    SE-->>PV: fail event tracked
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->