### PR TITLE
Option picking refactor and tests

### DIFF
--- a/superwall/src/main/java/com/superwall/sdk/analytics/internal/trackable/TrackableSuperwallEvent.kt
+++ b/superwall/src/main/java/com/superwall/sdk/analytics/internal/trackable/TrackableSuperwallEvent.kt
@@ -532,7 +532,7 @@ sealed class InternalSuperwallEvent(
             get() {
                 return paywallInfo.audienceFilterParams().let {
                     if (superwallPlacement is SuperwallEvent.TransactionAbandon) {
-                        it.plus("abandoned_product_id" to (product?.productIdentifier ?: ""))
+                        it.plus("abandoned_product_id" to (product?.fullIdentifier ?: ""))
                     } else {
                         it
                     }

--- a/superwall/src/main/java/com/superwall/sdk/analytics/superwall/TransactionProduct.kt
+++ b/superwall/src/main/java/com/superwall/sdk/analytics/superwall/TransactionProduct.kt
@@ -48,7 +48,7 @@ data class TransactionProduct(
     )
 
     constructor(product: StoreProduct) : this(
-        id = product.productIdentifier,
+        id = product.fullIdentifier,
         price =
             Price(
                 raw = product.price,

--- a/superwall/src/main/java/com/superwall/sdk/billing/DecomposedProductIds.kt
+++ b/superwall/src/main/java/com/superwall/sdk/billing/DecomposedProductIds.kt
@@ -1,30 +1,40 @@
 package com.superwall.sdk.billing
 
+import com.superwall.sdk.store.abstractions.product.BasePlanType
 import com.superwall.sdk.store.abstractions.product.OfferType
 
+/**
+ * Represents a decomposed product ID in the format: `productId:basePlan:offer`
+ *
+ * [basePlanType] uses [BasePlanType]:
+ * - [BasePlanType.Auto] when the value is "sw-auto", null, or empty
+ * - [BasePlanType.Specific] when a specific ID is provided
+ *
+ * [offerType] uses [OfferType]:
+ * - [OfferType.Auto] when the value is "sw-auto", null, or empty
+ * - [OfferType.None] when the value is "sw-none" (no offer)
+ * - [OfferType.Specific] when a specific ID is provided
+ */
 data class DecomposedProductIds(
     val subscriptionId: String,
-    val basePlanId: String,
+    val basePlanType: BasePlanType,
     val offerType: OfferType,
     val fullId: String,
 ) {
+    /** Returns the base plan ID if specific, null if auto */
+    val basePlanId: String? get() = basePlanType.specificId
+
     companion object {
         fun from(productId: String): DecomposedProductIds {
             val components = productId.split(":")
             val subscriptionId = components.getOrNull(0) ?: ""
-            val basePlanId = components.getOrNull(1) ?: ""
-            val offerId = components.getOrNull(2)
+            val rawBasePlan = components.getOrNull(1)
+            val rawOffer = components.getOrNull(2)
 
-            val offerType =
-                if (offerId == "sw-auto" || offerId == null) {
-                    OfferType.Auto
-                } else {
-                    OfferType.Offer(id = offerId)
-                }
             return DecomposedProductIds(
                 subscriptionId = subscriptionId,
-                basePlanId = basePlanId,
-                offerType = offerType,
+                basePlanType = BasePlanType.from(rawBasePlan),
+                offerType = OfferType.from(rawOffer),
                 fullId = productId,
             )
         }

--- a/superwall/src/main/java/com/superwall/sdk/billing/QueryProductDetailsUseCase.kt
+++ b/superwall/src/main/java/com/superwall/sdk/billing/QueryProductDetailsUseCase.kt
@@ -75,11 +75,12 @@ internal class QueryProductDetailsUseCase(
                         val rawStoreProduct =
                             RawStoreProduct(
                                 underlyingProductDetails = productDetails,
-                                fullIdentifier = productId.fullId ?: "",
-                                basePlanId = productId.basePlanId,
+                                fullIdentifier = productId.fullId,
+                                basePlanType = productId.basePlanType,
                                 offerType = productId.offerType,
                             )
-                        StoreProduct(rawStoreProduct)
+                        val storeProduct = StoreProduct(rawStoreProduct)
+                        storeProduct
                     } ?: emptyList()
                 }
 

--- a/superwall/src/main/java/com/superwall/sdk/models/paywall/Paywall.kt
+++ b/superwall/src/main/java/com/superwall/sdk/models/paywall/Paywall.kt
@@ -84,7 +84,10 @@ data class Paywall(
     @SerialName("products_v2")
     internal var _productItems: List<ProductItem> = emptyList(),
     @kotlinx.serialization.Transient()
-    var productIds: List<String> = _productItems.map { it.compositeId },
+    var productIds: List<String> =
+        _productItems.map { it.compositeId }.ifEmpty {
+            _productItemsV3.map { it.fullProductId }
+        },
     @kotlinx.serialization.Transient()
     var responseLoadingInfo: LoadingInfo = LoadingInfo(),
     @kotlinx.serialization.Transient()

--- a/superwall/src/main/java/com/superwall/sdk/models/product/CrossplatformProduct.kt
+++ b/superwall/src/main/java/com/superwall/sdk/models/product/CrossplatformProduct.kt
@@ -64,6 +64,7 @@ data class CrossplatformProduct(
                 get() =
                     when (offer) {
                         is Offer.Automatic -> "$productIdentifier:$basePlanIdentifier:sw-auto"
+                        is Offer.NoOffer -> "$productIdentifier:$basePlanIdentifier:sw-none"
                         is Offer.Specified -> "$productIdentifier:$basePlanIdentifier:${offer.offerIdentifier}"
                     }
 
@@ -171,6 +172,7 @@ object PlayStoreSerializer : KSerializer<CrossplatformProduct.StoreProduct.PlayS
                 val offer =
                     when (val offer = value.offer) {
                         is Offer.Automatic -> JsonObject(mapOf("type" to JsonPrimitive(offer.type)))
+                        is Offer.NoOffer -> JsonObject(mapOf("type" to JsonPrimitive(Offer.NoOffer.TYPE)))
                         is Offer.Specified ->
                             JsonObject(
                                 mapOf(
@@ -205,13 +207,14 @@ object PlayStoreSerializer : KSerializer<CrossplatformProduct.StoreProduct.PlayS
         val offer =
             when (type) {
                 "AUTOMATIC" -> Offer.Automatic()
+                "NO_OFFER" -> Offer.NoOffer
                 "SPECIFIED" -> {
                     val offerIdentifier =
                         offerJsonObject["offer_identifier"]?.jsonPrimitive?.content
                             ?: throw SerializationException("offer_identifier is missing")
                     Offer.Specified(offerIdentifier = offerIdentifier)
                 }
-                else -> Offer.Specified(offerIdentifier = "sw-none")
+                else -> Offer.NoOffer
             }
 
         return CrossplatformProduct.StoreProduct.PlayStore(productIdentifier, basePlanIdentifier, offer)

--- a/superwall/src/main/java/com/superwall/sdk/store/Entitlements.kt
+++ b/superwall/src/main/java/com/superwall/sdk/store/Entitlements.kt
@@ -181,12 +181,12 @@ class Entitlements(
         return checkFor(
             listOf(
                 decomposedProductIds.fullId,
-                "${decomposedProductIds.subscriptionId}:${decomposedProductIds.basePlanId}:${decomposedProductIds.offerType.id ?: ""}",
-                "${decomposedProductIds.subscriptionId}:${decomposedProductIds.basePlanId}",
+                "${decomposedProductIds.subscriptionId}:${decomposedProductIds.basePlanId ?: ""}:${decomposedProductIds.offerType.specificId ?: ""}",
+                "${decomposedProductIds.subscriptionId}:${decomposedProductIds.basePlanId ?: ""}",
             ),
         ) ?: checkFor(
             listOf(
-                "${decomposedProductIds.subscriptionId}:${decomposedProductIds.basePlanId}:",
+                "${decomposedProductIds.subscriptionId}:${decomposedProductIds.basePlanId ?: ""}:",
                 decomposedProductIds.subscriptionId,
             ),
             isExact = false,

--- a/superwall/src/main/java/com/superwall/sdk/store/StoreManager.kt
+++ b/superwall/src/main/java/com/superwall/sdk/store/StoreManager.kt
@@ -11,12 +11,10 @@ import com.superwall.sdk.logger.LogScope
 import com.superwall.sdk.logger.Logger
 import com.superwall.sdk.models.entitlements.Entitlement
 import com.superwall.sdk.models.paywall.Paywall
-import com.superwall.sdk.models.product.Offer
 import com.superwall.sdk.models.product.PlayStoreProduct
 import com.superwall.sdk.models.product.ProductItem
 import com.superwall.sdk.models.product.ProductVariable
 import com.superwall.sdk.paywall.request.PaywallRequest
-import com.superwall.sdk.store.abstractions.product.OfferType
 import com.superwall.sdk.store.abstractions.product.StoreProduct
 import com.superwall.sdk.store.abstractions.product.receipt.ReceiptManager
 import com.superwall.sdk.store.coordinator.ProductsFetcher
@@ -170,17 +168,7 @@ class StoreManager(
                             PlayStoreProduct(
                                 productIdentifier = decomposedProductIds.subscriptionId,
                                 basePlanIdentifier = decomposedProductIds.basePlanId ?: "",
-                                offer =
-                                    decomposedProductIds.offerType.let { offerType ->
-                                        when (offerType) {
-                                            is OfferType.Offer ->
-                                                Offer.Specified(
-                                                    offerIdentifier = offerType.id,
-                                                )
-
-                                            is OfferType.Auto -> Offer.Automatic()
-                                        }
-                                    },
+                                offer = decomposedProductIds.offerType.toOffer(),
                             ),
                         )
                     productItems[index] =
@@ -196,17 +184,7 @@ class StoreManager(
                             PlayStoreProduct(
                                 productIdentifier = decomposedProductIds.subscriptionId,
                                 basePlanIdentifier = decomposedProductIds.basePlanId ?: "",
-                                offer =
-                                    decomposedProductIds.offerType.let { offerType ->
-                                        when (offerType) {
-                                            is OfferType.Offer ->
-                                                Offer.Specified(
-                                                    offerIdentifier = offerType.id,
-                                                )
-
-                                            is OfferType.Auto -> Offer.Automatic()
-                                        }
-                                    },
+                                offer = decomposedProductIds.offerType.toOffer(),
                             ),
                         )
                     // If no existing product found, just append to the list.

--- a/superwall/src/main/java/com/superwall/sdk/store/abstractions/product/StoreProduct.kt
+++ b/superwall/src/main/java/com/superwall/sdk/store/abstractions/product/StoreProduct.kt
@@ -1,24 +1,79 @@
 package com.superwall.sdk.store.abstractions.product
 
+import com.superwall.sdk.models.product.Offer
 import kotlinx.serialization.Serializable
 import java.math.BigDecimal
 import java.util.*
 
-// TODO: Consolidate OfferType and Offer without breaking changes
+/**
+ * Selection type for base plan/purchase option.
+ * When [Auto], the SDK will automatically select the best base plan.
+ * When [Specific], the SDK will use the exact base plan ID provided.
+ */
+@Serializable
+sealed class BasePlanType {
+    /** Auto-select the best base plan */
+    object Auto : BasePlanType()
+
+    /** Use a specific base plan by ID */
+    data class Specific(
+        val id: String,
+    ) : BasePlanType()
+
+    /** Returns the ID if this is a Specific selection, null otherwise */
+    val specificId: String?
+        get() = (this as? Specific)?.id
+
+    companion object {
+        /** Parse a string value - "sw-auto"/null/empty means Auto, otherwise Specific */
+        fun from(value: String?): BasePlanType =
+            when {
+                value.isNullOrEmpty() || value == "sw-auto" -> Auto
+                else -> Specific(value)
+            }
+    }
+}
+
+/**
+ * Selection type for offer selection.
+ * When [Auto], the SDK will automatically select the best offer.
+ * When [None], no offer will be selected (use base plan/option only).
+ * When [Specific], the SDK will use the exact offer ID provided.
+ */
 @Serializable
 sealed class OfferType {
+    /** Auto-select the best offer (e.g., longest free trial or cheapest) */
     object Auto : OfferType()
 
-    data class Offer(
-        override val id: String,
+    /** Don't select any offer - use base plan/option only */
+    object None : OfferType()
+
+    /** Use a specific offer by ID */
+    data class Specific(
+        val id: String,
     ) : OfferType()
 
-    open val id: String?
-        get() =
-            when (this) {
-                is Offer -> id
-                else -> null
+    /** Returns the ID if this is a Specific selection, null otherwise */
+    val specificId: String?
+        get() = (this as? Specific)?.id
+
+    /** Converts to the Offer type used in ProductItem */
+    fun toOffer(): Offer =
+        when (this) {
+            is Auto -> Offer.Automatic()
+            is None -> Offer.NoOffer
+            is Specific -> Offer.Specified(offerIdentifier = id)
+        }
+
+    companion object {
+        /** Parse a string value - "sw-auto"/null/empty means Auto, "sw-none" means None, otherwise Specific */
+        fun from(value: String?): OfferType =
+            when {
+                value.isNullOrEmpty() || value == "sw-auto" -> Auto
+                value == "sw-none" -> None
+                else -> Specific(value)
             }
+    }
 }
 
 class StoreProduct(

--- a/superwall/src/main/java/com/superwall/sdk/store/abstractions/product/StoreProductType.kt
+++ b/superwall/src/main/java/com/superwall/sdk/store/abstractions/product/StoreProductType.kt
@@ -81,7 +81,8 @@ interface StoreProductType {
             attributes["languageCode"] = languageCode ?: "n/a"
             attributes["currencyCode"] = currencyCode ?: "n/a"
             attributes["currencySymbol"] = currencySymbol ?: "n/a"
-            attributes["identifier"] = productIdentifier
+            attributes["identifier"] = fullIdentifier
+            attributes["productIdentifier"] = productIdentifier
 
             return attributes
         }

--- a/superwall/src/test/java/com/superwall/sdk/analytics/internal/trackable/InternalSuperwallEventTest.kt
+++ b/superwall/src/test/java/com/superwall/sdk/analytics/internal/trackable/InternalSuperwallEventTest.kt
@@ -540,7 +540,7 @@ class InternalSuperwallEventTest {
         runTest {
             Given("an abandoned transaction") {
                 val paywallInfo = stubPaywallInfo()
-                val product = stubStoreProduct(productId = "prod_1")
+                val product = stubStoreProduct(productId = "prod_1", fullId = "prod_1:option:offer")
                 val event =
                     InternalSuperwallEvent.Transaction(
                         state = InternalSuperwallEvent.Transaction.State.Abandon(product),
@@ -556,8 +556,8 @@ class InternalSuperwallEventTest {
                 When("audience filters are requested") {
                     val filters = event.audienceFilterParams
 
-                    Then("the abandoned product identifier is included") {
-                        assertEquals("prod_1", filters["abandoned_product_id"])
+                    Then("the abandoned product full identifier is included") {
+                        assertEquals("prod_1:option:offer", filters["abandoned_product_id"])
                     }
                 }
             }

--- a/superwall/src/test/java/com/superwall/sdk/billing/DecomposedProductIdsTest.kt
+++ b/superwall/src/test/java/com/superwall/sdk/billing/DecomposedProductIdsTest.kt
@@ -1,0 +1,199 @@
+package com.superwall.sdk.billing
+
+import com.superwall.sdk.store.abstractions.product.BasePlanType
+import com.superwall.sdk.store.abstractions.product.OfferType
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * Tests for [DecomposedProductIds] parsing with all permutations of:
+ * - Product ID only
+ * - Product ID + base plan (specific, sw-auto, empty)
+ * - Product ID + base plan + offer (specific, sw-auto, null)
+ */
+class DecomposedProductIdsTest {
+    // ==================== PRODUCT ID ONLY ====================
+
+    @Test
+    fun `productId only - returns Auto for both basePlan and offer`() {
+        val result = DecomposedProductIds.from("my_product")
+
+        assertEquals("my_product", result.subscriptionId)
+        assertEquals(BasePlanType.Auto, result.basePlanType)
+        assertEquals(OfferType.Auto, result.offerType)
+        assertNull(result.basePlanId)
+        assertNull(result.offerType.specificId)
+        assertEquals("my_product", result.fullId)
+    }
+
+    // ==================== SPECIFIC BASE PLAN + NULL OFFER ====================
+
+    @Test
+    fun `specific basePlan and null offer - returns Specific basePlan and Auto offer`() {
+        val result = DecomposedProductIds.from("my_product:monthly_plan")
+
+        assertEquals("my_product", result.subscriptionId)
+        assertEquals(BasePlanType.Specific("monthly_plan"), result.basePlanType)
+        assertEquals(OfferType.Auto, result.offerType)
+        assertEquals("monthly_plan", result.basePlanId)
+        assertNull(result.offerType.specificId)
+    }
+
+    // ==================== SPECIFIC BASE PLAN + SW-AUTO OFFER ====================
+
+    @Test
+    fun `specific basePlan and sw-auto offer - returns Specific basePlan and Auto offer`() {
+        val result = DecomposedProductIds.from("my_product:monthly_plan:sw-auto")
+
+        assertEquals("my_product", result.subscriptionId)
+        assertEquals(BasePlanType.Specific("monthly_plan"), result.basePlanType)
+        assertEquals(OfferType.Auto, result.offerType)
+        assertEquals("monthly_plan", result.basePlanId)
+        assertNull(result.offerType.specificId)
+    }
+
+    // ==================== SPECIFIC BASE PLAN + SPECIFIC OFFER ====================
+
+    @Test
+    fun `specific basePlan and specific offer - returns both Specific`() {
+        val result = DecomposedProductIds.from("my_product:monthly_plan:free_trial_offer")
+
+        assertEquals("my_product", result.subscriptionId)
+        assertEquals(BasePlanType.Specific("monthly_plan"), result.basePlanType)
+        assertEquals(OfferType.Specific("free_trial_offer"), result.offerType)
+        assertEquals("monthly_plan", result.basePlanId)
+        assertEquals("free_trial_offer", result.offerType.specificId)
+    }
+
+    // ==================== SW-AUTO BASE PLAN + NULL OFFER ====================
+
+    @Test
+    fun `sw-auto basePlan and null offer - returns Auto for both`() {
+        val result = DecomposedProductIds.from("my_product:sw-auto")
+
+        assertEquals("my_product", result.subscriptionId)
+        assertEquals(BasePlanType.Auto, result.basePlanType)
+        assertEquals(OfferType.Auto, result.offerType)
+        assertNull(result.basePlanId)
+        assertNull(result.offerType.specificId)
+    }
+
+    // ==================== SW-AUTO BASE PLAN + SW-AUTO OFFER ====================
+
+    @Test
+    fun `sw-auto basePlan and sw-auto offer - returns Auto for both`() {
+        val result = DecomposedProductIds.from("my_product:sw-auto:sw-auto")
+
+        assertEquals("my_product", result.subscriptionId)
+        assertEquals(BasePlanType.Auto, result.basePlanType)
+        assertEquals(OfferType.Auto, result.offerType)
+        assertNull(result.basePlanId)
+        assertNull(result.offerType.specificId)
+    }
+
+    // ==================== SW-AUTO BASE PLAN + SPECIFIC OFFER ====================
+
+    @Test
+    fun `sw-auto basePlan and specific offer - returns Auto basePlan and Specific offer`() {
+        val result = DecomposedProductIds.from("my_product:sw-auto:promo_offer")
+
+        assertEquals("my_product", result.subscriptionId)
+        assertEquals(BasePlanType.Auto, result.basePlanType)
+        assertEquals(OfferType.Specific("promo_offer"), result.offerType)
+        assertNull(result.basePlanId)
+        assertEquals("promo_offer", result.offerType.specificId)
+    }
+
+    // ==================== EMPTY BASE PLAN + NULL OFFER ====================
+
+    @Test
+    fun `empty basePlan and null offer - returns Auto for both`() {
+        val result = DecomposedProductIds.from("my_product:")
+
+        assertEquals("my_product", result.subscriptionId)
+        assertEquals(BasePlanType.Auto, result.basePlanType)
+        assertEquals(OfferType.Auto, result.offerType)
+        assertNull(result.basePlanId)
+    }
+
+    // ==================== EMPTY BASE PLAN + SW-AUTO OFFER ====================
+
+    @Test
+    fun `empty basePlan and sw-auto offer - returns Auto for both`() {
+        val result = DecomposedProductIds.from("my_product::sw-auto")
+
+        assertEquals("my_product", result.subscriptionId)
+        assertEquals(BasePlanType.Auto, result.basePlanType)
+        assertEquals(OfferType.Auto, result.offerType)
+        assertNull(result.basePlanId)
+    }
+
+    // ==================== EMPTY BASE PLAN + SPECIFIC OFFER ====================
+
+    @Test
+    fun `empty basePlan and specific offer - returns Auto basePlan and Specific offer`() {
+        val result = DecomposedProductIds.from("my_product::discount_offer")
+
+        assertEquals("my_product", result.subscriptionId)
+        assertEquals(BasePlanType.Auto, result.basePlanType)
+        assertEquals(OfferType.Specific("discount_offer"), result.offerType)
+        assertNull(result.basePlanId)
+        assertEquals("discount_offer", result.offerType.specificId)
+    }
+
+    // ==================== SW-NONE OFFER (NO OFFER) ====================
+
+    @Test
+    fun `specific basePlan and sw-none offer - returns Specific basePlan and None offer`() {
+        val result = DecomposedProductIds.from("my_product:monthly_plan:sw-none")
+
+        assertEquals("my_product", result.subscriptionId)
+        assertEquals(BasePlanType.Specific("monthly_plan"), result.basePlanType)
+        assertEquals(OfferType.None, result.offerType)
+        assertEquals("monthly_plan", result.basePlanId)
+        assertNull(result.offerType.specificId)
+    }
+
+    @Test
+    fun `sw-auto basePlan and sw-none offer - returns Auto basePlan and None offer`() {
+        val result = DecomposedProductIds.from("my_product:sw-auto:sw-none")
+
+        assertEquals("my_product", result.subscriptionId)
+        assertEquals(BasePlanType.Auto, result.basePlanType)
+        assertEquals(OfferType.None, result.offerType)
+        assertNull(result.basePlanId)
+        assertNull(result.offerType.specificId)
+    }
+
+    @Test
+    fun `empty basePlan and sw-none offer - returns Auto basePlan and None offer`() {
+        val result = DecomposedProductIds.from("my_product::sw-none")
+
+        assertEquals("my_product", result.subscriptionId)
+        assertEquals(BasePlanType.Auto, result.basePlanType)
+        assertEquals(OfferType.None, result.offerType)
+        assertNull(result.basePlanId)
+    }
+
+    // ==================== FULL ID PRESERVATION ====================
+
+    @Test
+    fun `fullId is preserved exactly as input`() {
+        val inputs =
+            listOf(
+                "product",
+                "product:plan",
+                "product:plan:offer",
+                "product:sw-auto",
+                "product:sw-auto:sw-auto",
+                "product:plan:sw-none",
+                "product::offer",
+            )
+
+        inputs.forEach { input ->
+            val result = DecomposedProductIds.from(input)
+            assertEquals(input, result.fullId)
+        }
+    }
+}

--- a/superwall/src/test/java/com/superwall/sdk/models/paywall/PaywallProductIdsTest.kt
+++ b/superwall/src/test/java/com/superwall/sdk/models/paywall/PaywallProductIdsTest.kt
@@ -1,0 +1,246 @@
+package com.superwall.sdk.models.paywall
+
+import kotlinx.serialization.json.Json
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Tests for [Paywall.productIds] initialization behavior.
+ *
+ * The issue: When the server sends only `products_v3` (not `products_v2`),
+ * `productIds` should still be populated from `products_v3` data.
+ * Otherwise, no products would be fetched from Google Play.
+ */
+class PaywallProductIdsTest {
+    private val json =
+        Json {
+            ignoreUnknownKeys = true
+        }
+
+    // Base paywall fields required for deserialization
+    private fun basePaywallFields() =
+        """
+        "id": "test-id",
+        "identifier": "test-paywall",
+        "name": "Test Paywall",
+        "url": "https://example.com",
+        "paywalljs_event": "",
+        "presentation_style_v2": null,
+        "presentation_style_v3": null,
+        "presentation_delay": 0,
+        "presentation_condition": "CHECK_USER_SUBSCRIPTION",
+        "background_color_hex": "#FFFFFF",
+        "cache_key": "test-cache-key",
+        "build_id": "test-build"
+        """.trimIndent()
+
+    @Test
+    fun `productIds populated from products_v2 when both v2 and v3 exist`() {
+        // Given: A paywall JSON with both products_v2 and products_v3
+        val paywallJson =
+            """
+            {
+                ${basePaywallFields()},
+                "products_v2": [
+                    {
+                        "reference_name": "primary",
+                        "sw_composite_product_id": "product1:plan1:offer1",
+                        "store_product": {
+                            "store": "PLAY_STORE",
+                            "product_identifier": "product1",
+                            "base_plan_identifier": "plan1",
+                            "offer": {"type": "SPECIFIED", "offer_identifier": "offer1"}
+                        }
+                    }
+                ],
+                "products_v3": [
+                    {
+                        "sw_composite_product_id": "product1:plan1:offer1",
+                        "reference_name": "primary",
+                        "store_product": {
+                            "store": "PLAY_STORE",
+                            "product_identifier": "product1",
+                            "base_plan_identifier": "plan1",
+                            "offer": {"type": "SPECIFIED", "offer_identifier": "offer1"}
+                        },
+                        "entitlements": []
+                    }
+                ]
+            }
+            """.trimIndent()
+
+        // When: Parsing the paywall
+        val paywall = json.decodeFromString<Paywall>(paywallJson)
+
+        // Then: productIds should be populated from products_v2
+        assertEquals(1, paywall.productIds.size)
+        assertEquals("product1:plan1:offer1", paywall.productIds[0])
+    }
+
+    @Test
+    fun `productIds populated from products_v3 when products_v2 is empty`() {
+        // Given: A paywall JSON with only products_v3 (products_v2 is empty)
+        val paywallJson =
+            """
+            {
+                ${basePaywallFields()},
+                "products_v2": [],
+                "products_v3": [
+                    {
+                        "sw_composite_product_id": "product1:plan1:offer1",
+                        "reference_name": "primary",
+                        "store_product": {
+                            "store": "PLAY_STORE",
+                            "product_identifier": "product1",
+                            "base_plan_identifier": "plan1",
+                            "offer": {"type": "SPECIFIED", "offer_identifier": "offer1"}
+                        },
+                        "entitlements": []
+                    },
+                    {
+                        "sw_composite_product_id": "product1:plan2:offer2",
+                        "reference_name": "secondary",
+                        "store_product": {
+                            "store": "PLAY_STORE",
+                            "product_identifier": "product1",
+                            "base_plan_identifier": "plan2",
+                            "offer": {"type": "SPECIFIED", "offer_identifier": "offer2"}
+                        },
+                        "entitlements": []
+                    }
+                ]
+            }
+            """.trimIndent()
+
+        // When: Parsing the paywall
+        val paywall = json.decodeFromString<Paywall>(paywallJson)
+
+        // Then: productIds should be populated from products_v3 (fallback)
+        assertEquals(2, paywall.productIds.size)
+        assertTrue(paywall.productIds.contains("product1:plan1:offer1"))
+        assertTrue(paywall.productIds.contains("product1:plan2:offer2"))
+    }
+
+    @Test
+    fun `productIds populated from products_v3 when products_v2 is missing`() {
+        // Given: A paywall JSON without products_v2 field at all
+        val paywallJson =
+            """
+            {
+                ${basePaywallFields()},
+                "products_v3": [
+                    {
+                        "sw_composite_product_id": "product1:monthly:trial",
+                        "reference_name": "monthly",
+                        "store_product": {
+                            "store": "PLAY_STORE",
+                            "product_identifier": "product1",
+                            "base_plan_identifier": "monthly",
+                            "offer": {"type": "SPECIFIED", "offer_identifier": "trial"}
+                        },
+                        "entitlements": []
+                    }
+                ]
+            }
+            """.trimIndent()
+
+        // When: Parsing the paywall
+        val paywall = json.decodeFromString<Paywall>(paywallJson)
+
+        // Then: productIds should be populated from products_v3 (fallback)
+        assertEquals(1, paywall.productIds.size)
+        assertEquals("product1:monthly:trial", paywall.productIds[0])
+    }
+
+    @Test
+    fun `productIds correctly populated for multiple products with same productId but different plans`() {
+        // Given: A paywall with products that share the same Google productId but different plans
+        // This is the scenario that was causing issues: "productid:plan:offer" vs "productid:plan2:offer"
+        val paywallJson =
+            """
+            {
+                ${basePaywallFields()},
+                "products_v3": [
+                    {
+                        "sw_composite_product_id": "my_subscription:monthly:free_trial",
+                        "reference_name": "Monthly with Trial",
+                        "store_product": {
+                            "store": "PLAY_STORE",
+                            "product_identifier": "my_subscription",
+                            "base_plan_identifier": "monthly",
+                            "offer": {"type": "SPECIFIED", "offer_identifier": "free_trial"}
+                        },
+                        "entitlements": []
+                    },
+                    {
+                        "sw_composite_product_id": "my_subscription:annual:free_trial",
+                        "reference_name": "Annual with Trial",
+                        "store_product": {
+                            "store": "PLAY_STORE",
+                            "product_identifier": "my_subscription",
+                            "base_plan_identifier": "annual",
+                            "offer": {"type": "SPECIFIED", "offer_identifier": "free_trial"}
+                        },
+                        "entitlements": []
+                    }
+                ]
+            }
+            """.trimIndent()
+
+        // When: Parsing the paywall
+        val paywall = json.decodeFromString<Paywall>(paywallJson)
+
+        // Then: Both product IDs should be present (different plans for same product)
+        assertEquals(2, paywall.productIds.size)
+        assertTrue(paywall.productIds.contains("my_subscription:monthly:free_trial"))
+        assertTrue(paywall.productIds.contains("my_subscription:annual:free_trial"))
+
+        // And: playStoreProducts should also have both
+        assertEquals(2, paywall.playStoreProducts.size)
+    }
+
+    @Test
+    fun `productIds uses fullProductId computed from store product details`() {
+        // Given: A paywall where compositeId might differ from computed fullProductId
+        // This tests that the fallback uses fullProductId (computed from store product details)
+        val paywallJson =
+            """
+            {
+                ${basePaywallFields()},
+                "products_v3": [
+                    {
+                        "sw_composite_product_id": "product:plan:sw-auto",
+                        "reference_name": "Auto Offer",
+                        "store_product": {
+                            "store": "PLAY_STORE",
+                            "product_identifier": "product",
+                            "base_plan_identifier": "plan",
+                            "offer": {"type": "AUTOMATIC"}
+                        },
+                        "entitlements": []
+                    },
+                    {
+                        "sw_composite_product_id": "product:plan:sw-none",
+                        "reference_name": "No Offer",
+                        "store_product": {
+                            "store": "PLAY_STORE",
+                            "product_identifier": "product",
+                            "base_plan_identifier": "plan",
+                            "offer": {"type": "NO_OFFER"}
+                        },
+                        "entitlements": []
+                    }
+                ]
+            }
+            """.trimIndent()
+
+        // When: Parsing the paywall
+        val paywall = json.decodeFromString<Paywall>(paywallJson)
+
+        // Then: productIds should contain the compositeIds (which are the fullProductIds)
+        assertEquals(2, paywall.productIds.size)
+        assertTrue(paywall.productIds.contains("product:plan:sw-auto"))
+        assertTrue(paywall.productIds.contains("product:plan:sw-none"))
+    }
+}

--- a/superwall/src/test/java/com/superwall/sdk/products/ProductFetcherTest.kt
+++ b/superwall/src/test/java/com/superwall/sdk/products/ProductFetcherTest.kt
@@ -4,6 +4,7 @@ package com.superwall.sdk.products
 
 import com.android.billingclient.api.BillingClient.ProductType
 import com.android.billingclient.api.ProductDetails.RecurrenceMode
+import com.superwall.sdk.store.abstractions.product.BasePlanType
 import com.superwall.sdk.store.abstractions.product.OfferType
 import com.superwall.sdk.store.abstractions.product.RawStoreProduct
 import com.superwall.sdk.store.abstractions.product.StoreProduct
@@ -18,6 +19,8 @@ import java.util.Currency
 import java.util.Locale
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 class ProductFetcherInstrumentedTest {
@@ -308,8 +311,8 @@ class ProductFetcherInstrumentedTest {
                     RawStoreProduct(
                         underlyingProductDetails = productDetails,
                         fullIdentifier = "com.ui_tests.quarterly2:test-2:free-trial-offer",
-                        basePlanId = "test-2",
-                        offerType = OfferType.Offer(id = "free-trial-offer"),
+                        basePlanType = BasePlanType.Specific("test-2"),
+                        offerType = OfferType.Specific("free-trial-offer"),
                     ),
             )
         assertTrue(storeProduct.hasFreeTrial)
@@ -359,8 +362,8 @@ class ProductFetcherInstrumentedTest {
                     RawStoreProduct(
                         underlyingProductDetails = productDetails,
                         fullIdentifier = "com.ui_tests.quarterly2:test-2:trial-and-paid-offer",
-                        basePlanId = "test-2",
-                        offerType = OfferType.Offer(id = "trial-and-paid-offer"),
+                        basePlanType = BasePlanType.Specific("test-2"),
+                        offerType = OfferType.Specific("trial-and-paid-offer"),
                     ),
             )
         assertTrue(storeProduct.hasFreeTrial)
@@ -409,8 +412,8 @@ class ProductFetcherInstrumentedTest {
                     RawStoreProduct(
                         underlyingProductDetails = productDetails,
                         fullIdentifier = "com.ui_tests.quarterly2:test-4:paid-offer",
-                        basePlanId = "test-4",
-                        offerType = OfferType.Offer(id = "paid-offer"),
+                        basePlanType = BasePlanType.Specific("test-4"),
+                        offerType = OfferType.Specific("paid-offer"),
                     ),
             )
         assertTrue(storeProduct.hasFreeTrial)
@@ -461,7 +464,7 @@ class ProductFetcherInstrumentedTest {
                     RawStoreProduct(
                         underlyingProductDetails = productDetails,
                         fullIdentifier = "com.ui_tests.quarterly2:test-2:sw-auto",
-                        basePlanId = "test-2",
+                        basePlanType = BasePlanType.Specific("test-2"),
                         offerType = OfferType.Auto,
                     ),
             )
@@ -512,7 +515,7 @@ class ProductFetcherInstrumentedTest {
                     RawStoreProduct(
                         underlyingProductDetails = productDetails,
                         fullIdentifier = "com.ui_tests.quarterly2:test-3:sw-auto",
-                        basePlanId = "test-3",
+                        basePlanType = BasePlanType.Specific("test-3"),
                         offerType = OfferType.Auto,
                     ),
             )
@@ -564,7 +567,7 @@ class ProductFetcherInstrumentedTest {
                     RawStoreProduct(
                         underlyingProductDetails = productDetails,
                         fullIdentifier = "com.ui_tests.quarterly2:test-5:sw-auto",
-                        basePlanId = "test-5",
+                        basePlanType = BasePlanType.Specific("test-5"),
                         offerType = OfferType.Auto,
                     ),
             )
@@ -609,8 +612,8 @@ class ProductFetcherInstrumentedTest {
                     RawStoreProduct(
                         underlyingProductDetails = productDetails,
                         fullIdentifier = "com.ui_tests.quarterly2:test-5",
-                        basePlanId = "test-5",
-                        offerType = null,
+                        basePlanType = BasePlanType.Specific("test-5"),
+                        offerType = OfferType.Auto,
                     ),
             )
         assertFalse(storeProduct.hasFreeTrial)
@@ -654,8 +657,8 @@ class ProductFetcherInstrumentedTest {
                     RawStoreProduct(
                         underlyingProductDetails = productDetails,
                         fullIdentifier = "com.ui_tests.quarterly2:test-5",
-                        basePlanId = "test-5",
-                        offerType = OfferType.Offer(id = "doesnt-exist"),
+                        basePlanType = BasePlanType.Specific("test-5"),
+                        offerType = OfferType.Specific("doesnt-exist"),
                     ),
             )
         assertFalse(storeProduct.hasFreeTrial)
@@ -702,8 +705,8 @@ class ProductFetcherInstrumentedTest {
                     RawStoreProduct(
                         underlyingProductDetails = productDetails,
                         fullIdentifier = "com.ui_tests.quarterly2",
-                        basePlanId = null,
-                        offerType = null,
+                        basePlanType = BasePlanType.Auto,
+                        offerType = OfferType.Auto,
                     ),
             )
         assertFalse(storeProduct.hasFreeTrial)
@@ -747,8 +750,8 @@ class ProductFetcherInstrumentedTest {
                     RawStoreProduct(
                         underlyingProductDetails = oneTimePurchaseProduct,
                         fullIdentifier = "pro_test_8999_year",
-                        basePlanId = null,
-                        offerType = null,
+                        basePlanType = BasePlanType.Auto,
+                        offerType = OfferType.Auto,
                     ),
             )
         assertFalse(storeProduct.hasFreeTrial)
@@ -841,8 +844,8 @@ class ProductFetcherInstrumentedTest {
                     RawStoreProduct(
                         underlyingProductDetails = otpWithPurchaseOptionsProduct,
                         fullIdentifier = "otp_with_options:first-buy-option:fifty-off",
-                        basePlanId = "first-buy-option",
-                        offerType = OfferType.Offer(id = "fifty-off"),
+                        basePlanType = BasePlanType.Specific("first-buy-option"),
+                        offerType = OfferType.Specific("fifty-off"),
                     ),
             )
 
@@ -866,8 +869,8 @@ class ProductFetcherInstrumentedTest {
                     RawStoreProduct(
                         underlyingProductDetails = otpWithPurchaseOptionsProduct,
                         fullIdentifier = "otp_with_options:second-buy-option:nonexistent-offer",
-                        basePlanId = "second-buy-option",
-                        offerType = OfferType.Offer(id = "nonexistent-offer"),
+                        basePlanType = BasePlanType.Specific("second-buy-option"),
+                        offerType = OfferType.Specific("nonexistent-offer"),
                     ),
             )
 
@@ -887,8 +890,8 @@ class ProductFetcherInstrumentedTest {
                     RawStoreProduct(
                         underlyingProductDetails = otpWithPurchaseOptionsProduct,
                         fullIdentifier = "otp_with_options::fifty-off",
-                        basePlanId = "", // Auto/empty
-                        offerType = OfferType.Offer(id = "fifty-off"),
+                        basePlanType = BasePlanType.Auto,
+                        offerType = OfferType.Specific("fifty-off"),
                     ),
             )
 
@@ -908,7 +911,7 @@ class ProductFetcherInstrumentedTest {
                     RawStoreProduct(
                         underlyingProductDetails = otpWithPurchaseOptionsProduct,
                         fullIdentifier = "otp_with_options:first-buy-option:sw-auto",
-                        basePlanId = "first-buy-option",
+                        basePlanType = BasePlanType.Specific("first-buy-option"),
                         offerType = OfferType.Auto,
                     ),
             )
@@ -929,7 +932,7 @@ class ProductFetcherInstrumentedTest {
                     RawStoreProduct(
                         underlyingProductDetails = otpWithPurchaseOptionsProduct,
                         fullIdentifier = "otp_with_options:second-buy-option:sw-auto",
-                        basePlanId = "second-buy-option",
+                        basePlanType = BasePlanType.Specific("second-buy-option"),
                         offerType = OfferType.Auto,
                     ),
             )
@@ -950,7 +953,7 @@ class ProductFetcherInstrumentedTest {
                     RawStoreProduct(
                         underlyingProductDetails = otpWithPurchaseOptionsProduct,
                         fullIdentifier = "otp_with_options::sw-auto",
-                        basePlanId = "", // Auto
+                        basePlanType = BasePlanType.Auto,
                         offerType = OfferType.Auto,
                     ),
             )
@@ -1001,7 +1004,7 @@ class ProductFetcherInstrumentedTest {
                     RawStoreProduct(
                         underlyingProductDetails = otpNoOffersProduct,
                         fullIdentifier = "otp_no_offers::sw-auto",
-                        basePlanId = "",
+                        basePlanType = BasePlanType.Auto,
                         offerType = OfferType.Auto,
                     ),
             )
@@ -1021,8 +1024,8 @@ class ProductFetcherInstrumentedTest {
                     RawStoreProduct(
                         underlyingProductDetails = otpWithPurchaseOptionsProduct,
                         fullIdentifier = "otp_with_options:first-buy-option:fifty-off",
-                        basePlanId = "first-buy-option",
-                        offerType = OfferType.Offer(id = "fifty-off"),
+                        basePlanType = BasePlanType.Specific("first-buy-option"),
+                        offerType = OfferType.Specific("fifty-off"),
                     ),
             )
 
@@ -1038,6 +1041,41 @@ class ProductFetcherInstrumentedTest {
     }
 
     /**
+     * Test that OTP with specific purchase option but no discount offer
+     * has purchaseOptionId set and offerId null.
+     * This is important because the offerToken is still needed to purchase
+     * the correct purchase option even without a discount offer.
+     */
+    @Test
+    fun test_storeProduct_otp_specificOption_noOffer_hasPurchaseOptionIdWithNullOfferId() {
+        val storeProduct =
+            StoreProduct(
+                rawStoreProduct =
+                    RawStoreProduct(
+                        underlyingProductDetails = otpWithPurchaseOptionsProduct,
+                        fullIdentifier = "otp_with_options:second-buy-option:sw-auto",
+                        basePlanType = BasePlanType.Specific("second-buy-option"),
+                        offerType = OfferType.Auto,
+                    ),
+            )
+
+        val selectedOffer = storeProduct.rawStoreProduct.selectedOffer
+        assertNotNull(selectedOffer, "Expected selectedOffer to be non-null")
+        assertTrue(
+            selectedOffer is RawStoreProduct.SelectedOfferDetails.OneTime,
+            "Expected SelectedOfferDetails.OneTime, got ${selectedOffer?.javaClass?.simpleName}",
+        )
+
+        val oneTimeOffer = selectedOffer as RawStoreProduct.SelectedOfferDetails.OneTime
+        // purchaseOptionId should be set even without a discount offer
+        assertEquals("second-buy-option", oneTimeOffer.purchaseOptionId, "Expected purchaseOptionId second-buy-option")
+        // offerId should be null since we're using auto offer and there's no discount
+        assertNull(oneTimeOffer.offerId, "Expected offerId to be null for purchase option without discount")
+        // The offerToken should still be available for Google Play billing
+        assertNotNull(oneTimeOffer.underlying.offerToken, "Expected offerToken to be non-null")
+    }
+
+    /**
      * Test that OTP properties return expected values (no subscription-specific values)
      */
     @Test
@@ -1048,8 +1086,8 @@ class ProductFetcherInstrumentedTest {
                     RawStoreProduct(
                         underlyingProductDetails = otpWithPurchaseOptionsProduct,
                         fullIdentifier = "otp_with_options:first-buy-option:fifty-off",
-                        basePlanId = "first-buy-option",
-                        offerType = OfferType.Offer(id = "fifty-off"),
+                        basePlanType = BasePlanType.Specific("first-buy-option"),
+                        offerType = OfferType.Specific("fifty-off"),
                     ),
             )
 

--- a/superwall/src/test/java/com/superwall/sdk/store/abstractions/product/OfferTypeTest.kt
+++ b/superwall/src/test/java/com/superwall/sdk/store/abstractions/product/OfferTypeTest.kt
@@ -1,0 +1,135 @@
+package com.superwall.sdk.store.abstractions.product
+
+import com.superwall.sdk.models.product.Offer
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Tests for [OfferType] factory method and conversions.
+ */
+class OfferTypeTest {
+    // ==================== FROM() FACTORY METHOD ====================
+
+    @Test
+    fun `from null returns Auto`() {
+        val result = OfferType.from(null)
+        assertEquals(OfferType.Auto, result)
+    }
+
+    @Test
+    fun `from empty string returns Auto`() {
+        val result = OfferType.from("")
+        assertEquals(OfferType.Auto, result)
+    }
+
+    @Test
+    fun `from sw-auto returns Auto`() {
+        val result = OfferType.from("sw-auto")
+        assertEquals(OfferType.Auto, result)
+    }
+
+    @Test
+    fun `from sw-none returns None`() {
+        val result = OfferType.from("sw-none")
+        assertEquals(OfferType.None, result)
+    }
+
+    @Test
+    fun `from specific value returns Specific with that value`() {
+        val result = OfferType.from("monthly_plan")
+        assertEquals(OfferType.Specific("monthly_plan"), result)
+        assertEquals("monthly_plan", result.specificId)
+    }
+
+    @Test
+    fun `from whitespace only returns Specific (not treated as empty)`() {
+        // Whitespace is treated as a specific value, not empty
+        val result = OfferType.from("  ")
+        assertTrue(result is OfferType.Specific)
+        assertEquals("  ", result.specificId)
+    }
+
+    // ==================== SPECIFIC ID ====================
+
+    @Test
+    fun `Auto specificId returns null`() {
+        assertNull(OfferType.Auto.specificId)
+    }
+
+    @Test
+    fun `None specificId returns null`() {
+        assertNull(OfferType.None.specificId)
+    }
+
+    @Test
+    fun `Specific specificId returns the id`() {
+        val specific = OfferType.Specific("my_plan")
+        assertEquals("my_plan", specific.specificId)
+    }
+
+    // ==================== TO OFFER CONVERSION ====================
+
+    @Test
+    fun `Auto toOffer returns Offer Automatic`() {
+        val result = OfferType.Auto.toOffer()
+        assertTrue(result is Offer.Automatic)
+    }
+
+    @Test
+    fun `None toOffer returns Offer NoOffer`() {
+        val result = OfferType.None.toOffer()
+        assertTrue(result is Offer.NoOffer)
+    }
+
+    @Test
+    fun `Specific toOffer returns Offer Specified with correct id`() {
+        val result = OfferType.Specific("promo_offer").toOffer()
+        assertTrue(result is Offer.Specified)
+        assertEquals("promo_offer", (result as Offer.Specified).offerIdentifier)
+    }
+
+    // ==================== EQUALITY ====================
+
+    @Test
+    fun `Auto equals Auto`() {
+        assertEquals(OfferType.Auto, OfferType.Auto)
+    }
+
+    @Test
+    fun `None equals None`() {
+        assertEquals(OfferType.None, OfferType.None)
+    }
+
+    @Test
+    fun `Specific with same id are equal`() {
+        val a = OfferType.Specific("plan_a")
+        val b = OfferType.Specific("plan_a")
+        assertEquals(a, b)
+    }
+
+    @Test
+    fun `Specific with different ids are not equal`() {
+        val a = OfferType.Specific("plan_a")
+        val b = OfferType.Specific("plan_b")
+        assertTrue(a != b)
+    }
+
+    @Test
+    fun `Auto and Specific are not equal`() {
+        val auto = OfferType.Auto
+        val specific = OfferType.Specific("plan")
+        assertTrue(auto != specific)
+    }
+
+    @Test
+    fun `Auto and None are not equal`() {
+        assertTrue(OfferType.Auto != OfferType.None)
+    }
+
+    @Test
+    fun `None and Specific are not equal`() {
+        assertTrue(OfferType.None != OfferType.Specific("plan"))
+    }
+}


### PR DESCRIPTION
## Changes in this pull request

- Refactor option picking for full ID usage and provide a type-safe base plan type

### Checklist

- [ ] All unit tests pass.
- [ ] All UI tests pass.
- [ ] Demo project builds and runs.
- [ ] I added/updated tests or detailed why my change isn't tested.
- [ ] I added an entry to the `CHANGELOG.md` for any breaking changes, enhancements, or bug fixes.
- [ ] I have run `ktlint` in the main directory and fixed any issues.
- [ ] I have updated the SDK documentation as well as the online docs.
- [ ] I have reviewed the [contributing guide](https://github.com/superwall/Superwall-Android/tree/master/.github/CONTRIBUTING.md)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Refactored product option selection from string-based to type-safe sealed classes (`BasePlanType` and `OfferType`), introducing support for `sw-auto` and `sw-none` special values.

**Key changes:**
- Introduced `BasePlanType` sealed class (Auto, Specific) to replace nullable string `basePlanId`
- Introduced `OfferType` sealed class (Auto, None, Specific) with `toOffer()` conversion method
- Updated `DecomposedProductIds` to parse and use these type-safe representations
- Enhanced one-time purchase handling to support purchase options with offer tokens
- Added comprehensive test coverage for the new types (199 new test lines in `DecomposedProductIdsTest`, 135 in `OfferTypeTest`, 246 in `PaywallProductIdsTest`)
- Simplified offer conversion logic in `StoreManager` using the new `toOffer()` method
- Updated `Paywall.productIds` to fallback to `products_v3` when `products_v2` is empty

**Additional changes:**
- Added consume calls for in-app purchases in `AutomaticPurchaseController.syncSubscriptionStatusAndWait()` and `queryPurchasesOfType()`
- Updated offer token logic for one-time purchases to handle purchase options correctly

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with one area requiring verification around in-app purchase consumption behavior
- The refactoring is well-structured with comprehensive test coverage (580+ new test lines). The type-safe sealed classes improve code safety and clarity. However, the added consume calls for in-app purchases in `AutomaticPurchaseController` warrant verification to ensure they don't inadvertently consume purchases that should persist (e.g., non-consumable in-app purchases or purchases that need to be validated server-side first).
- Pay close attention to `superwall/src/main/java/com/superwall/sdk/store/AutomaticPurchaseController.kt` - verify the in-app purchase consumption behavior is intentional and won't affect non-consumable products

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| superwall/src/main/java/com/superwall/sdk/store/abstractions/product/StoreProduct.kt | Added BasePlanType and OfferType sealed classes for type-safe product option selection, replacing string-based approach |
| superwall/src/main/java/com/superwall/sdk/store/abstractions/product/RawStoreProduct.kt | Refactored to use BasePlanType instead of basePlanId string; updated one-time purchase logic to handle purchase options with offer tokens |
| superwall/src/main/java/com/superwall/sdk/billing/DecomposedProductIds.kt | Updated to use BasePlanType and OfferType sealed classes for parsing product IDs with sw-auto and sw-none support |
| superwall/src/main/java/com/superwall/sdk/store/AutomaticPurchaseController.kt | Updated to use BasePlanType/OfferType; added offer token logic for one-time purchases with purchase options; added consume calls for in-app purchases |
| superwall/src/test/java/com/superwall/sdk/billing/DecomposedProductIdsTest.kt | Comprehensive test suite for DecomposedProductIds parsing with all permutations of base plan and offer types |
| superwall/src/test/java/com/superwall/sdk/store/abstractions/product/OfferTypeTest.kt | New test suite for OfferType sealed class, covering factory methods, conversions, and equality checks |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Client as SDK Client
    participant QueryUseCase as QueryProductDetailsUseCase
    participant Decomposer as DecomposedProductIds
    participant RawProduct as RawStoreProduct
    participant OfferSelection as Offer Selection Logic
    participant BillingClient as Google BillingClient

    Client->>QueryUseCase: Query products (productId:basePlan:offer)
    QueryUseCase->>Decomposer: Parse product ID
    Decomposer->>Decomposer: Split by ":"
    Decomposer->>Decomposer: Parse basePlan (sw-auto → Auto, specific ID → Specific)
    Decomposer->>Decomposer: Parse offer (sw-auto → Auto, sw-none → None, specific ID → Specific)
    Decomposer-->>QueryUseCase: DecomposedProductIds(basePlanType, offerType)
    
    QueryUseCase->>BillingClient: Query product details from Google Play
    BillingClient-->>QueryUseCase: ProductDetails
    
    QueryUseCase->>RawProduct: Create RawStoreProduct(details, basePlanType, offerType)
    RawProduct->>OfferSelection: getSelectedOfferDetails()
    
    alt One-Time Purchase Product
        OfferSelection->>OfferSelection: Check offerType
        alt offerType is None (sw-none)
            OfferSelection->>OfferSelection: Filter purchase options without offers
            OfferSelection->>OfferSelection: Select cheapest option
        else offerType is Specific
            OfferSelection->>OfferSelection: Filter by specific offer ID
        else offerType is Auto
            OfferSelection->>OfferSelection: Select option with lowest price
        end
        OfferSelection-->>RawProduct: SelectedOfferDetails.OneTime
    else Subscription Product
        OfferSelection->>OfferSelection: Check basePlanType
        alt basePlanType is Specific
            OfferSelection->>OfferSelection: Filter offers by base plan ID
        else basePlanType is Auto
            OfferSelection->>OfferSelection: Use first base plan
        end
        
        OfferSelection->>OfferSelection: Check offerType
        alt offerType is Auto
            OfferSelection->>OfferSelection: Find longest free trial
            OfferSelection->>OfferSelection: Or find cheapest offer
        else offerType is None
            OfferSelection->>OfferSelection: Use base plan only
        else offerType is Specific
            OfferSelection->>OfferSelection: Find offer by ID
        end
        OfferSelection-->>RawProduct: SelectedOfferDetails.Subscription
    end
    
    RawProduct-->>QueryUseCase: StoreProduct with selected offer
    QueryUseCase-->>Client: List<StoreProduct>
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->