### PR TITLE
Fix date locale formatting for products

### DIFF
--- a/superwall/src/main/java/com/superwall/sdk/models/product/StripeProductType.kt
+++ b/superwall/src/main/java/com/superwall/sdk/models/product/StripeProductType.kt
@@ -3,6 +3,8 @@ package com.superwall.sdk.models.product
 import com.superwall.sdk.models.serialization.BigDecimalSerializer
 import com.superwall.sdk.store.abstractions.product.StoreProductType
 import com.superwall.sdk.store.abstractions.product.SubscriptionPeriod
+import com.superwall.sdk.utilities.DateUtils
+import com.superwall.sdk.utilities.localizedDateFormat
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import java.math.BigDecimal
@@ -221,7 +223,7 @@ data class StripeProductType(
         }
 
     override val trialPeriodEndDateString: String
-        get() = trialPeriodEndDate?.toString() ?: ""
+        get() = trialPeriodEndDate?.let { localizedDateFormat(DateUtils.MMM_dd_yyyy).format(it) } ?: ""
 
     override val trialPeriodDays: Int
         get() =

--- a/superwall/src/main/java/com/superwall/sdk/store/abstractions/product/RawStoreProduct.kt
+++ b/superwall/src/main/java/com/superwall/sdk/store/abstractions/product/RawStoreProduct.kt
@@ -6,7 +6,7 @@ import com.android.billingclient.api.ProductDetails.SubscriptionOfferDetails
 import com.superwall.sdk.billing.DecomposedProductIds
 import com.superwall.sdk.contrib.threeteen.AmountFormats
 import com.superwall.sdk.utilities.DateUtils
-import com.superwall.sdk.utilities.dateFormat
+import com.superwall.sdk.utilities.localizedDateFormat
 import kotlinx.serialization.Transient
 import org.threeten.bp.Period
 import java.math.BigDecimal
@@ -488,7 +488,7 @@ class RawStoreProduct(
 
     override val trialPeriodEndDateString by lazy {
         trialPeriodEndDate?.let {
-            val dateFormatter = dateFormat(DateUtils.MMM_dd_yyyy)
+            val dateFormatter = localizedDateFormat(DateUtils.MMM_dd_yyyy)
             dateFormatter.format(it)
         } ?: ""
     }

--- a/superwall/src/main/java/com/superwall/sdk/utilities/DateUtils.kt
+++ b/superwall/src/main/java/com/superwall/sdk/utilities/DateUtils.kt
@@ -15,4 +15,6 @@ internal object DateUtils {
 
 internal fun dateFormat(format: String = DateUtils.ISO_MILLIS) = SimpleDateFormat(format, Locale.US)
 
+internal fun localizedDateFormat(format: String = DateUtils.MMM_dd_yyyy) = SimpleDateFormat(format, Locale.getDefault())
+
 internal val DateFormatterUtil = dateFormat()

--- a/superwall/src/test/java/com/superwall/sdk/products/ProductFetcherTest.kt
+++ b/superwall/src/test/java/com/superwall/sdk/products/ProductFetcherTest.kt
@@ -347,7 +347,7 @@ class ProductFetcherInstrumentedTest {
 
         val currentDate = LocalDate.now()
         val dateIn30Days = currentDate.plusMonths(1)
-        val dateFormatter = DateTimeFormatter.ofPattern(DateUtils.MMM_dd_yyyy, Locale.US)
+        val dateFormatter = DateTimeFormatter.ofPattern(DateUtils.MMM_dd_yyyy, Locale.getDefault())
         val formattedDate = dateIn30Days.format(dateFormatter)
         println("Comparing -${storeProduct.trialPeriodEndDateString}- with -$formattedDate-")
         assertEquals(formattedDate, storeProduct.trialPeriodEndDateString)
@@ -398,7 +398,7 @@ class ProductFetcherInstrumentedTest {
 
         val currentDate = LocalDate.now()
         val dateIn30Days = currentDate.plusMonths(1)
-        val dateFormatter = DateTimeFormatter.ofPattern(DateUtils.MMM_dd_yyyy, Locale.US)
+        val dateFormatter = DateTimeFormatter.ofPattern(DateUtils.MMM_dd_yyyy, Locale.getDefault())
         val formattedDate = dateIn30Days.format(dateFormatter)
         assertEquals(formattedDate, storeProduct.trialPeriodEndDateString)
     }
@@ -448,7 +448,7 @@ class ProductFetcherInstrumentedTest {
 
         val currentDate = LocalDate.now()
         val dateIn30Days = currentDate.plusMonths(1)
-        val dateFormatter = DateTimeFormatter.ofPattern(DateUtils.MMM_dd_yyyy, Locale.US)
+        val dateFormatter = DateTimeFormatter.ofPattern(DateUtils.MMM_dd_yyyy, Locale.getDefault())
         val formattedDate = dateIn30Days.format(dateFormatter)
         assertEquals(formattedDate, storeProduct.trialPeriodEndDateString)
     }
@@ -500,7 +500,7 @@ class ProductFetcherInstrumentedTest {
 
         val currentDate = LocalDate.now()
         val dateIn30Days = currentDate.plusMonths(1)
-        val dateFormatter = DateTimeFormatter.ofPattern(DateUtils.MMM_dd_yyyy, Locale.US)
+        val dateFormatter = DateTimeFormatter.ofPattern(DateUtils.MMM_dd_yyyy, Locale.getDefault())
         val formattedDate = dateIn30Days.format(dateFormatter)
         assertEquals(formattedDate, storeProduct.trialPeriodEndDateString)
     }
@@ -553,7 +553,7 @@ class ProductFetcherInstrumentedTest {
 
         val currentDate = LocalDate.now()
         val dateIn30Days = currentDate.plusMonths(1)
-        val dateFormatter = DateTimeFormatter.ofPattern(DateUtils.MMM_dd_yyyy, Locale.US)
+        val dateFormatter = DateTimeFormatter.ofPattern(DateUtils.MMM_dd_yyyy, Locale.getDefault())
         val formattedDate = dateIn30Days.format(dateFormatter)
         assertEquals(formattedDate, storeProduct.trialPeriodEndDateString)
     }


### PR DESCRIPTION
## Changes in this pull request

- Fix date locale formatting for trial in products

### Checklist

- [ ] All unit tests pass.
- [ ] All UI tests pass.
- [ ] Demo project builds and runs.
- [ ] I added/updated tests or detailed why my change isn't tested.
- [ ] I added an entry to the `CHANGELOG.md` for any breaking changes, enhancements, or bug fixes.
- [ ] I have run `ktlint` in the main directory and fixed any issues.
- [ ] I have updated the SDK documentation as well as the online docs.
- [ ] I have reviewed the [contributing guide](https://github.com/superwall/Superwall-Android/tree/master/.github/CONTRIBUTING.md)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR fixes trial period end date formatting to respect the user's device locale instead of always using US locale. Previously, `trialPeriodEndDateString` would always format dates in US format (e.g., "Jan 15, 2026") regardless of the device's locale settings. Now it uses the device's default locale, ensuring dates appear in the format users expect based on their regional settings.

**Key changes:**
- Added new `localizedDateFormat()` utility function that uses `Locale.getDefault()` instead of `Locale.US`
- Updated `RawStoreProduct.trialPeriodEndDateString` to use localized formatting
- Fixed `StripeProductType.trialPeriodEndDateString` which was incorrectly using `Date.toString()` (would produce a format like "Wed Jan 15 00:00:00 GMT 2026")
- Updated all related tests to validate against localized date format

This is a user-facing improvement that ensures proper internationalization of trial period dates displayed in paywalls.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The changes are straightforward and well-tested. The PR adds proper locale support for date formatting, improving internationalization. All tests have been updated to match the new behavior, and the change is backwards-compatible in terms of functionality (dates still display correctly, just in the user's preferred format).
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| superwall/src/main/java/com/superwall/sdk/utilities/DateUtils.kt | Added `localizedDateFormat()` function to format dates using device locale instead of hardcoded US locale |
| superwall/src/main/java/com/superwall/sdk/store/abstractions/product/RawStoreProduct.kt | Updated `trialPeriodEndDateString` to use `localizedDateFormat()` for proper locale formatting |
| superwall/src/main/java/com/superwall/sdk/models/product/StripeProductType.kt | Updated `trialPeriodEndDateString` to use `localizedDateFormat()` instead of `Date.toString()` |
| superwall/src/test/java/com/superwall/sdk/products/ProductFetcherTest.kt | Updated test assertions to use `Locale.getDefault()` to match the new localized date formatting behavior |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Paywall
    participant StoreProduct
    participant RawStoreProduct
    participant StripeProductType
    participant DateUtils
    
    Paywall->>StoreProduct: Access trialPeriodEndDateString
    StoreProduct->>RawStoreProduct: Get trialPeriodEndDateString
    RawStoreProduct->>RawStoreProduct: Check trialPeriodEndDate
    RawStoreProduct->>DateUtils: Call localizedDateFormat(MMM_dd_yyyy)
    DateUtils-->>RawStoreProduct: Return SimpleDateFormat with Locale.getDefault()
    RawStoreProduct->>RawStoreProduct: Format date
    RawStoreProduct-->>StoreProduct: Return formatted date string
    StoreProduct-->>Paywall: Return localized date (e.g., "Jan 15, 2026")
    
    Note over Paywall,DateUtils: Alternative path for Stripe products
    Paywall->>StripeProductType: Access trialPeriodEndDateString
    StripeProductType->>StripeProductType: Check trialPeriodEndDate
    StripeProductType->>DateUtils: Call localizedDateFormat(MMM_dd_yyyy)
    DateUtils-->>StripeProductType: Return SimpleDateFormat with Locale.getDefault()
    StripeProductType->>StripeProductType: Format date
    StripeProductType-->>Paywall: Return localized date string
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->