### PR TITLE
Enable product replacement

### DIFF
--- a/superwall/src/main/java/com/superwall/sdk/Superwall.kt
+++ b/superwall/src/main/java/com/superwall/sdk/Superwall.kt
@@ -1337,6 +1337,30 @@ class Superwall(
                         }
                 }
 
+                is PaywallWebEvent.InitiateReplacement -> {
+                    if (purchaseTask != null) {
+                        return@launchWithTracking
+                    }
+                    paywallView.updateState(
+                        PaywallViewState.Updates.SetLoadingState(PaywallLoadingState.LoadingPurchase),
+                    )
+                    purchaseTask =
+                        launch {
+                            try {
+                                dependencyContainer.transactionManager.purchase(
+                                    Internal(
+                                        paywallEvent.productId,
+                                        paywallView.controller.state,
+                                        paywallEvent.replacementMode,
+                                    ),
+                                    shouldDismiss = paywallEvent.shouldDismiss,
+                                )
+                            } finally {
+                                purchaseTask = null
+                            }
+                        }
+                }
+
                 is InitiateRestore -> {
                     dependencyContainer.transactionManager.tryToRestorePurchases(paywallView)
                 }

--- a/superwall/src/main/java/com/superwall/sdk/paywall/view/webview/messaging/PaywallMessage.kt
+++ b/superwall/src/main/java/com/superwall/sdk/paywall/view/webview/messaging/PaywallMessage.kt
@@ -7,6 +7,7 @@ import com.superwall.sdk.models.paywall.LocalNotificationType
 import com.superwall.sdk.paywall.presentation.CustomCallbackBehavior
 import com.superwall.sdk.permissions.PermissionType
 import com.superwall.sdk.storage.core_data.convertFromJsonElement
+import com.superwall.sdk.store.ReplacementMode
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.booleanOrNull
@@ -66,6 +67,13 @@ sealed class PaywallMessage {
     data class Purchase(
         val product: String,
         val productId: String,
+        val shouldDismiss: Boolean,
+    ) : PaywallMessage()
+
+    data class ReplaceProduct(
+        val product: String,
+        val productId: String,
+        val replacementMode: ReplacementMode,
         val shouldDismiss: Boolean,
     ) : PaywallMessage()
 
@@ -200,6 +208,21 @@ private fun parsePaywallMessage(json: JsonObject): PaywallMessage {
                 json["product_identifier"]!!.jsonPrimitive.content,
                 json["should_dismiss"]?.jsonPrimitive?.booleanOrNull ?: true,
             )
+
+        "replace_product" -> {
+            val modeRaw =
+                json["replacement_mode"]?.jsonPrimitive?.contentOrNull
+                    ?: throw IllegalArgumentException("replace_product missing replacement_mode")
+            val mode =
+                ReplacementMode.fromRaw(modeRaw)
+                    ?: throw IllegalArgumentException("Unknown replacement_mode: $modeRaw")
+            PaywallMessage.ReplaceProduct(
+                product = json["product"]!!.jsonPrimitive.content,
+                productId = json["product_identifier"]!!.jsonPrimitive.content,
+                replacementMode = mode,
+                shouldDismiss = json["should_dismiss"]?.jsonPrimitive?.booleanOrNull ?: true,
+            )
+        }
 
         "custom" -> PaywallMessage.Custom(json["data"]!!.jsonPrimitive.content)
         "custom_placement" ->

--- a/superwall/src/main/java/com/superwall/sdk/paywall/view/webview/messaging/PaywallMessageHandler.kt
+++ b/superwall/src/main/java/com/superwall/sdk/paywall/view/webview/messaging/PaywallMessageHandler.kt
@@ -180,6 +180,18 @@ class PaywallMessageHandler(
                     shouldDismiss = message.shouldDismiss,
                 )
 
+            is PaywallMessage.ReplaceProduct -> {
+                detectHiddenPaywallEvent("replace_product")
+                hapticFeedback()
+                messageHandler?.eventDidOccur(
+                    PaywallWebEvent.InitiateReplacement(
+                        productId = message.productId,
+                        replacementMode = message.replacementMode,
+                        shouldDismiss = message.shouldDismiss,
+                    ),
+                )
+            }
+
             is PaywallMessage.PaywallOpen -> {
                 if (messageHandler?.state?.paywall?.paywalljsVersion == null) {
                     queue.offer(message)

--- a/superwall/src/main/java/com/superwall/sdk/paywall/view/webview/messaging/PaywallWebEvent.kt
+++ b/superwall/src/main/java/com/superwall/sdk/paywall/view/webview/messaging/PaywallWebEvent.kt
@@ -4,6 +4,7 @@ import android.net.Uri
 import com.superwall.sdk.models.paywall.LocalNotification
 import com.superwall.sdk.paywall.presentation.CustomCallbackBehavior
 import com.superwall.sdk.permissions.PermissionType
+import com.superwall.sdk.store.ReplacementMode
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.JsonObject
@@ -16,6 +17,13 @@ sealed class PaywallWebEvent {
     @SerialName("initiate_purchase")
     data class InitiatePurchase(
         val productId: String,
+        val shouldDismiss: Boolean,
+    ) : PaywallWebEvent()
+
+    @SerialName("initiate_replacement")
+    data class InitiateReplacement(
+        val productId: String,
+        val replacementMode: ReplacementMode,
         val shouldDismiss: Boolean,
     ) : PaywallWebEvent()
 

--- a/superwall/src/main/java/com/superwall/sdk/store/AutomaticPurchaseController.kt
+++ b/superwall/src/main/java/com/superwall/sdk/store/AutomaticPurchaseController.kt
@@ -270,6 +270,92 @@ class AutomaticPurchaseController(
         return value
     }
 
+    suspend fun replaceProduct(
+        activity: Activity,
+        productDetails: ProductDetails,
+        basePlanId: String?,
+        offerId: String?,
+        replacementMode: Int,
+    ): PurchaseResult {
+        purchaseResults.value = null
+
+        val fullId =
+            buildFullId(
+                subscriptionId = productDetails.productId,
+                basePlanId = basePlanId,
+                offerId = offerId,
+            )
+
+        val rawStoreProduct =
+            RawStoreProduct(
+                underlyingProductDetails = productDetails,
+                fullIdentifier = fullId,
+                basePlanType = BasePlanType.from(basePlanId),
+                offerType = OfferType.from(offerId),
+            )
+
+        val offerToken =
+            when (val offer = rawStoreProduct.selectedOffer) {
+                is RawStoreProduct.SelectedOfferDetails.Subscription -> offer.underlying.offerToken
+                is RawStoreProduct.SelectedOfferDetails.OneTime -> {
+                    if (offer.purchaseOptionId != null || offerId != null) {
+                        offer.underlying.offerToken
+                    } else {
+                        null
+                    }
+                }
+                null -> null
+            }
+
+        val hasOfferToken = !offerToken.isNullOrEmpty()
+
+        val productDetailsParams =
+            BillingFlowParams.ProductDetailsParams
+                .newBuilder()
+                .setProductDetails(productDetails)
+                .also {
+                    if (hasOfferToken) {
+                        it.setOfferToken(offerToken!!)
+                    }
+                }.build()
+
+        isConnected.first { it }
+
+        val oldToken =
+            findActiveSubscriptionToken()
+                ?: return PurchaseResult.Failed("No active subscription found for replacement")
+
+        val subscriptionUpdateParams =
+            BillingFlowParams.SubscriptionUpdateParams
+                .newBuilder()
+                .setOldPurchaseToken(oldToken)
+                .setSubscriptionReplacementMode(replacementMode)
+                .build()
+
+        val flowParams =
+            BillingFlowParams
+                .newBuilder()
+                .apply {
+                    setObfuscatedAccountId(Superwall.instance.externalAccountId)
+                }.setProductDetailsParamsList(listOf(productDetailsParams))
+                .setSubscriptionUpdateParams(subscriptionUpdateParams)
+                .build()
+
+        billingClient.launchBillingFlow(activity, flowParams)
+
+        val value = purchaseResults.first { it != null } ?: PurchaseResult.Failed("Purchase failed")
+        return value
+    }
+
+    private suspend fun findActiveSubscriptionToken(): String? {
+        isConnected.first { it }
+        val purchases =
+            queryPurchasesOfType(BillingClient.ProductType.SUBS).getOrNull() ?: return null
+        return purchases
+            .firstOrNull { it.purchaseState == Purchase.PurchaseState.PURCHASED }
+            ?.purchaseToken
+    }
+
     override suspend fun restorePurchases(): RestorationResult {
         syncSubscriptionStatusAndWait()
         return RestorationResult.Restored()

--- a/superwall/src/main/java/com/superwall/sdk/store/InternalPurchaseController.kt
+++ b/superwall/src/main/java/com/superwall/sdk/store/InternalPurchaseController.kt
@@ -21,6 +21,9 @@ class InternalPurchaseController(
     val hasInternalPurchaseController: Boolean
         get() = kotlinPurchaseController is AutomaticPurchaseController
 
+    val automaticPurchaseController: AutomaticPurchaseController?
+        get() = kotlinPurchaseController as? AutomaticPurchaseController
+
     override suspend fun purchase(
         activity: Activity,
         productDetails: ProductDetails,

--- a/superwall/src/main/java/com/superwall/sdk/store/ReplacementMode.kt
+++ b/superwall/src/main/java/com/superwall/sdk/store/ReplacementMode.kt
@@ -1,0 +1,17 @@
+package com.superwall.sdk.store
+
+enum class ReplacementMode(
+    val rawName: String,
+    val playBillingMode: Int,
+) {
+    DEFAULT("default", 1),
+    CHARGE_LATER("charge_later", 3),
+    CHARGE_NOW("charge_now", 5),
+    CHARGE_DIFFERENCE("charge_difference", 2),
+    CHARGE_ON_EXPIRE("charge_on_expire", 6),
+    ;
+
+    companion object {
+        fun fromRaw(value: String): ReplacementMode? = entries.firstOrNull { it.rawName == value }
+    }
+}

--- a/superwall/src/main/java/com/superwall/sdk/store/transactions/TransactionManager.kt
+++ b/superwall/src/main/java/com/superwall/sdk/store/transactions/TransactionManager.kt
@@ -43,6 +43,7 @@ import com.superwall.sdk.storage.EventsQueue
 import com.superwall.sdk.storage.PurchasingProductdIds
 import com.superwall.sdk.storage.Storage
 import com.superwall.sdk.store.PurchasingObserverState
+import com.superwall.sdk.store.ReplacementMode
 import com.superwall.sdk.store.StoreManager
 import com.superwall.sdk.store.abstractions.product.RawStoreProduct
 import com.superwall.sdk.store.abstractions.product.StoreProduct
@@ -87,6 +88,7 @@ class TransactionManager(
         data class Internal(
             val productId: String,
             val state: PaywallViewState,
+            val replacementMode: ReplacementMode? = null,
         ) : PurchaseSource() {
             val paywallInfo: PaywallInfo
                 get() = state.info
@@ -362,12 +364,29 @@ class TransactionManager(
 
         prepareToPurchase(product, purchaseSource)
         val result =
-            storeManager.purchaseController.purchase(
-                activity = activity,
-                productDetails = productDetails,
-                offerId = rawStoreProduct.offerId,
-                basePlanId = rawStoreProduct.basePlanId,
-            )
+            if (
+                purchaseSource is PurchaseSource.Internal &&
+                purchaseSource.replacementMode != null &&
+                storeManager.purchaseController.hasInternalPurchaseController
+            ) {
+                val automatic =
+                    storeManager.purchaseController.automaticPurchaseController
+                        ?: return PurchaseResult.Failed("Internal purchase controller unavailable")
+                automatic.replaceProduct(
+                    activity = activity,
+                    productDetails = productDetails,
+                    basePlanId = rawStoreProduct.basePlanId,
+                    offerId = rawStoreProduct.offerId,
+                    replacementMode = purchaseSource.replacementMode.playBillingMode,
+                )
+            } else {
+                storeManager.purchaseController.purchase(
+                    activity = activity,
+                    productDetails = productDetails,
+                    offerId = rawStoreProduct.offerId,
+                    basePlanId = rawStoreProduct.basePlanId,
+                )
+            }
 
         if (purchaseSource is PurchaseSource.ExternalPurchase &&
             factory.makeHasExternalPurchaseController() &&


### PR DESCRIPTION
## Changes in this pull request

- Add product change ability

### Checklist

- [ ] All unit tests pass.
- [ ] All UI tests pass.
- [ ] Demo project builds and runs.
- [ ] I added/updated tests or detailed why my change isn't tested.
- [ ] I added an entry to the `CHANGELOG.md` for any breaking changes, enhancements, or bug fixes.
- [ ] I have run `ktlint` in the main directory and fixed any issues.
- [ ] I have updated the SDK documentation as well as the online docs.
- [ ] I have reviewed the [contributing guide](https://github.com/superwall/Superwall-Android/tree/master/.github/CONTRIBUTING.md)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds subscription product replacement (upgrade/downgrade) support to the Superwall Android SDK via Google Play Billing's `SubscriptionUpdateParams`. A new `replace_product` message from the paywall webview flows through the existing message handling pipeline and ultimately calls `BillingClient.launchBillingFlow()` with subscription update parameters.

- Adds `ReplacementMode` enum mapping Superwall mode names (`default`, `charge_later`, `charge_now`, `charge_difference`, `charge_on_expire`) to Play Billing `SubscriptionUpdateParams.ReplacementMode` integer constants
- Introduces `ReplaceProduct` paywall message and `InitiateReplacement` web event through the existing message pipeline
- Adds `replaceProduct()` to `AutomaticPurchaseController` which builds `SubscriptionUpdateParams` and launches the billing flow
- `findActiveSubscriptionToken()` picks the first active subscription token for replacement, which could select the wrong subscription when a user has multiple active subscriptions
- Only works with the internal (automatic) purchase controller; external purchase controllers silently fall back to the normal purchase path without replacement semantics

<h3>Confidence Score: 3/5</h3>

- The feature implementation is structurally sound but the subscription token selection logic could replace the wrong subscription for users with multiple active subscriptions.
- The PR introduces a well-structured feature following existing patterns in the codebase. However, findActiveSubscriptionToken() arbitrarily picks the first active subscription, which is a correctness concern in multi-subscription scenarios. The ReplacementMode enum values correctly map to Play Billing constants. No tests are included for the new functionality.
- Pay close attention to `AutomaticPurchaseController.kt` — specifically `findActiveSubscriptionToken()` and `replaceProduct()` for multi-subscription edge cases.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| superwall/src/main/java/com/superwall/sdk/store/ReplacementMode.kt | New enum mapping replacement mode names to Google Play Billing SubscriptionUpdateParams.ReplacementMode integer constants. All values match the official API correctly. |
| superwall/src/main/java/com/superwall/sdk/paywall/view/webview/messaging/PaywallMessage.kt | Adds `ReplaceProduct` message variant and its JSON parser for the `replace_product` event from the webview. Parsing includes proper validation of `replacement_mode`. |
| superwall/src/main/java/com/superwall/sdk/paywall/view/webview/messaging/PaywallWebEvent.kt | Adds `InitiateReplacement` web event carrying productId, replacementMode, and shouldDismiss. Clean addition following existing patterns. |
| superwall/src/main/java/com/superwall/sdk/paywall/view/webview/messaging/PaywallMessageHandler.kt | Routes `ReplaceProduct` messages to `InitiateReplacement` events. Correctly includes hidden paywall detection and haptic feedback, consistent with other purchase flows. |
| superwall/src/main/java/com/superwall/sdk/Superwall.kt | Handles `InitiateReplacement` event by delegating to `TransactionManager.purchase()` with `replacementMode`. Follows the same guard/loading/task pattern as `InitiatePurchase`. |
| superwall/src/main/java/com/superwall/sdk/store/AutomaticPurchaseController.kt | Adds `replaceProduct()` and `findActiveSubscriptionToken()`. The token lookup picks the first active subscription arbitrarily which could replace the wrong subscription when multiple are active. |
| superwall/src/main/java/com/superwall/sdk/store/InternalPurchaseController.kt | Exposes `automaticPurchaseController` property via safe cast. Simple, correct addition. |
| superwall/src/main/java/com/superwall/sdk/store/transactions/TransactionManager.kt | Adds optional `replacementMode` to `PurchaseSource.Internal` and branches purchase logic to call `replaceProduct()` when replacement mode is set and internal controller is active. Falls back to normal purchase path otherwise. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant WV as PaywallWebView
    participant PMH as PaywallMessageHandler
    participant SW as Superwall
    participant TM as TransactionManager
    participant APC as AutomaticPurchaseController
    participant GPB as Google Play Billing

    WV->>PMH: replace_product message
    PMH->>PMH: Parse ReplaceProduct (productId, replacementMode, shouldDismiss)
    PMH->>SW: InitiateReplacement event
    SW->>SW: Guard: purchaseTask == null
    SW->>SW: Set LoadingPurchase state
    SW->>TM: purchase(Internal(productId, state, replacementMode))
    TM->>TM: Check: replacementMode != null && hasInternalPurchaseController
    TM->>APC: replaceProduct(activity, productDetails, basePlanId, offerId, replacementMode)
    APC->>APC: findActiveSubscriptionToken()
    APC->>GPB: queryPurchasesAsync(SUBS)
    GPB-->>APC: List of active purchases
    APC->>APC: Build SubscriptionUpdateParams with oldToken + replacementMode
    APC->>GPB: launchBillingFlow(flowParams)
    GPB-->>APC: PurchaseResult via onPurchasesUpdated
    APC-->>TM: PurchaseResult
    TM-->>SW: Handle result (success/fail/cancel)
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: superwall/src/main/java/com/superwall/sdk/store/AutomaticPurchaseController.kt
Line: 350-357

Comment:
**Picks arbitrary subscription for replacement**

`findActiveSubscriptionToken()` returns the first subscription with `PURCHASED` state. When a user has multiple active subscriptions, this may select the wrong one to replace. The `replaceProduct` method receives `productDetails` for the *new* product but has no information about which *existing* subscription should be replaced.

Consider accepting a target product ID (or the old subscription's product ID) and filtering the purchases to find the matching subscription token. For example:

```suggestion
    private suspend fun findActiveSubscriptionToken(targetProductId: String? = null): String? {
        isConnected.first { it }
        val purchases =
            queryPurchasesOfType(BillingClient.ProductType.SUBS).getOrNull() ?: return null
        return purchases
            .filter { it.purchaseState == Purchase.PurchaseState.PURCHASED }
            .let { active ->
                if (targetProductId != null) {
                    active.firstOrNull { it.products.contains(targetProductId) }
                } else {
                    active.firstOrNull()
                }
            }
            ?.purchaseToken
    }
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Last reviewed commit: b95aa07</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->