### PR TITLE
Adds prioritized campaigns support

### DIFF
--- a/superwall/src/main/java/com/superwall/sdk/config/PaywallPreload.kt
+++ b/superwall/src/main/java/com/superwall/sdk/config/PaywallPreload.kt
@@ -19,6 +19,7 @@ import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.delay
 
 class PaywallPreload(
     val factory: Factory,
@@ -52,6 +53,30 @@ class PaywallPreload(
                         preloadingDisabled = config.preloadingDisabled,
                     )
                 val confirmedAssignments = storage.getConfirmedAssignments()
+
+                // If there's a prioritized campaign, preload its paywalls first.
+                val prioritizedCampaignId = config.prioritizedCampaignId
+                if (prioritizedCampaignId != null) {
+                    val prioritizedTriggers =
+                        triggers.filter { trigger ->
+                            trigger.rules.any { it.experimentGroupId == prioritizedCampaignId }
+                        }.toSet()
+                    if (prioritizedTriggers.isNotEmpty()) {
+                        val prioritizedIds =
+                            ConfigLogic.getAllActiveTreatmentPaywallIds(
+                                triggers = prioritizedTriggers,
+                                confirmedAssignments = confirmedAssignments,
+                                unconfirmedAssignments = assignments.unconfirmedAssignments,
+                                expressionEvaluator = expressionEvaluator,
+                            )
+                        preloadPaywalls(paywallIdentifiers = prioritizedIds)
+
+                        // Delay before preloading the rest to avoid resource contention.
+                        delay(5000)
+                    }
+                }
+
+                // Then preload all remaining paywalls.
                 val paywallIds =
                     ConfigLogic.getAllActiveTreatmentPaywallIds(
                         triggers = triggers,

--- a/superwall/src/main/java/com/superwall/sdk/models/config/Config.kt
+++ b/superwall/src/main/java/com/superwall/sdk/models/config/Config.kt
@@ -29,6 +29,7 @@ data class Config(
     @SerialName("build_id") val buildId: String,
     @SerialName("bundle_id_config") val bundleIdConfig: String? = null,
     @SerialName("test_mode_user_ids") val testModeUserIds: List<TestStoreUser>? = null,
+    @SerialName("prioritized_campaign_id") val prioritizedCampaignId: String? = null,
 ) : SerializableEntity {
     init {
         locales = localizationConfig.locales.map { it.locale }.toSet()


### PR DESCRIPTION
## Changes in this pull request

- Adds prioritized campaign support

### Checklist

- [ ] All unit tests pass.
- [ ] All UI tests pass.
- [ ] Demo project builds and runs.
- [ ] I added/updated tests or detailed why my change isn't tested.
- [ ] I added an entry to the `CHANGELOG.md` for any breaking changes, enhancements, or bug fixes.
- [ ] I have run `ktlint` in the main directory and fixed any issues.
- [ ] I have updated the SDK documentation as well as the online docs.
- [ ] I have reviewed the [contributing guide](https://github.com/superwall/Superwall-Android/tree/master/.github/CONTRIBUTING.md)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces prioritized campaign support: a new optional `prioritizedCampaignId` field is added to `Config`, and `PaywallPreload` is updated to detect that field at startup, preload the matching campaign's paywalls first, wait 5 seconds, then preload all remaining paywalls.

The `Config.kt` change is clean. The `PaywallPreload.kt` change has two logic issues that should be addressed before merging:

- **Double preloading of prioritized paywalls** – the second `getAllActiveTreatmentPaywallIds` call receives the full `triggers` set (which still contains the prioritized triggers), so their paywall IDs appear in both batches and are preloaded redundantly.
- **`delay(5000)` does not synchronize with actual completion** – `preloadPaywalls` launches a fire-and-forget child coroutine and returns immediately; the five-second pause is therefore only a heuristic, not a guarantee that prioritized paywalls are ready before the second batch begins.

<h3>Confidence Score: 4/5</h3>

Two P1 logic issues should be resolved before merging: duplicate preloading and an unsynchronized delay.

Two P1 findings exist: prioritized paywalls are preloaded twice (wasted network/memory), and the delay does not wait for the first batch to finish (ordering guarantee is broken). Both affect the primary feature being introduced.

PaywallPreload.kt — specifically the trigger-set scoping and the fire-and-forget delay around lines 60–88.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| superwall/src/main/java/com/superwall/sdk/config/PaywallPreload.kt | Adds prioritized-campaign preloading with two issues: (1) the second getAllActiveTreatmentPaywallIds call reuses the full trigger set, causing prioritized paywalls to be loaded twice; (2) preloadPaywalls is fire-and-forget so the 5s delay does not guarantee the prioritized batch finishes before the second batch starts. |
| superwall/src/main/java/com/superwall/sdk/models/config/Config.kt | Adds optional prioritizedCampaignId field with correct @SerialName annotation and a nullable default; no issues. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant PA as preloadAllPaywalls
    participant CL as ConfigLogic
    participant PP as preloadPaywalls
    participant SC as scope (IOScope)
    participant PM as PaywallManager

    PA->>CL: filterTriggers(config.triggers)
    CL-->>PA: triggers (full set)
    PA->>PA: check prioritizedCampaignId
    PA->>CL: getAllActiveTreatmentPaywallIds(prioritizedTriggers)
    CL-->>PA: prioritizedIds
    PA->>PP: preloadPaywalls(prioritizedIds)
    PP->>SC: launchWithTracking { ... }
    Note over PP,SC: Returns immediately (fire-and-forget)
    PP-->>PA: (returns)
    PA->>PA: delay(5000ms) ← heuristic only
    PA->>CL: getAllActiveTreatmentPaywallIds(triggers) ← full set includes prioritized
    CL-->>PA: paywallIds (includes prioritized IDs again)
    PA->>PP: preloadPaywalls(paywallIds)
    PP->>SC: launchWithTracking { ... }
    SC->>PM: getPaywallView(id) for each id
    PM-->>SC: PaywallView (cached)
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `superwall/src/main/java/com/superwall/sdk/config/PaywallPreload.kt`, line 80-88 ([link](https://github.com/superwall/superwall-android/blob/712e6449937118fbbad0205932acdb0942687e14/superwall/src/main/java/com/superwall/sdk/config/PaywallPreload.kt#L80-L88)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **Prioritized paywalls are preloaded a second time**

   The second `getAllActiveTreatmentPaywallIds` call is passed the full `triggers` set, which still includes the triggers belonging to the prioritized campaign. The resulting `paywallIds` set therefore contains all the same identifiers that were just preloaded in the prioritized batch, causing those paywalls to be fetched and cached again unnecessarily.

   To fix this, exclude the already-preloaded prioritized triggers from the second pass by hoisting `prioritizedTriggers` to the outer scope and subtracting it before the second call.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: superwall/src/main/java/com/superwall/sdk/config/PaywallPreload.kt
   Line: 80-88

   Comment:
   **Prioritized paywalls are preloaded a second time**

   The second `getAllActiveTreatmentPaywallIds` call is passed the full `triggers` set, which still includes the triggers belonging to the prioritized campaign. The resulting `paywallIds` set therefore contains all the same identifiers that were just preloaded in the prioritized batch, causing those paywalls to be fetched and cached again unnecessarily.

   To fix this, exclude the already-preloaded prioritized triggers from the second pass by hoisting `prioritizedTriggers` to the outer scope and subtracting it before the second call.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: superwall/src/main/java/com/superwall/sdk/config/PaywallPreload.kt
Line: 80-88

Comment:
**Prioritized paywalls are preloaded a second time**

The second `getAllActiveTreatmentPaywallIds` call is passed the full `triggers` set, which still includes the triggers belonging to the prioritized campaign. The resulting `paywallIds` set therefore contains all the same identifiers that were just preloaded in the prioritized batch, causing those paywalls to be fetched and cached again unnecessarily.

To fix this, exclude the already-preloaded prioritized triggers from the second pass by hoisting `prioritizedTriggers` to the outer scope and subtracting it before the second call.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: superwall/src/main/java/com/superwall/sdk/config/PaywallPreload.kt
Line: 72-75

Comment:
**`delay(5000)` does not wait for prioritized preloading to complete**

`preloadPaywalls()` is fire-and-forget: it immediately launches a new child coroutine via `scope.launchWithTracking { … }` and returns. Calling `delay(5000)` after it only pauses the outer coroutine for five seconds; it does **not** block until the prioritized paywalls have actually finished loading. If network conditions are slow, the second batch will start before the first finishes, defeating the purpose of the prioritization.

Consider having `preloadPaywalls` return the launched `Job` and then calling `join()` (or `withTimeoutOrNull(5_000) { job.join() }`) to synchronize on actual completion.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: superwall/src/main/java/com/superwall/sdk/config/PaywallPreload.kt
Line: 75

Comment:
**Magic number for delay duration**

The literal `5000` is hard to understand without the comment. Use Kotlin's `Duration` API for clarity:

```suggestion
                        delay(5.seconds)
```

Add `import kotlin.time.Duration.Companion.seconds` alongside the other imports.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Adds prioritized campaigns support"](https://github.com/superwall/superwall-android/commit/712e6449937118fbbad0205932acdb0942687e14) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27046131)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->