### PR TITLE
Add onboarding analytics support

### DIFF
--- a/superwall/src/main/java/com/superwall/sdk/analytics/internal/trackable/TrackableSuperwallEvent.kt
+++ b/superwall/src/main/java/com/superwall/sdk/analytics/internal/trackable/TrackableSuperwallEvent.kt
@@ -1,6 +1,7 @@
 package com.superwall.sdk.analytics.internal.trackable
 
 import com.superwall.sdk.analytics.superwall.SuperwallEvent
+import com.superwall.sdk.paywall.view.webview.messaging.PageViewData
 import com.superwall.sdk.analytics.superwall.TransactionProduct
 import com.superwall.sdk.config.models.Survey
 import com.superwall.sdk.config.models.SurveyOption
@@ -492,6 +493,27 @@ sealed class InternalSuperwallEvent(
             get() {
                 return paywallInfo.audienceFilterParams()
             }
+    }
+
+    class PaywallPageView(
+        val paywallInfo: PaywallInfo,
+        val data: PageViewData,
+    ) : InternalSuperwallEvent(SuperwallEvent.PaywallPageView(paywallInfo, data)) {
+        override val audienceFilterParams: Map<String, Any>
+            get() = paywallInfo.audienceFilterParams()
+
+        override suspend fun getSuperwallParameters(): HashMap<String, Any> {
+            val params = HashMap(paywallInfo.eventParams())
+            params["page_node_id"] = data.pageNodeId
+            params["flow_position"] = data.flowPosition
+            params["page_name"] = data.pageName
+            params["navigation_node_id"] = data.navigationNodeId
+            params["navigation_type"] = data.navigationType
+            data.previousPageNodeId?.let { params["previous_page_node_id"] = it }
+            data.previousFlowPosition?.let { params["previous_flow_position"] = it }
+            data.timeOnPreviousPageMs?.let { params["time_on_previous_page_ms"] = it }
+            return params
+        }
     }
 
     class Transaction(

--- a/superwall/src/main/java/com/superwall/sdk/analytics/superwall/SuperwallEvent.kt
+++ b/superwall/src/main/java/com/superwall/sdk/analytics/superwall/SuperwallEvent.kt
@@ -5,6 +5,7 @@ import com.superwall.sdk.config.models.SurveyOption
 import com.superwall.sdk.models.customer.CustomerInfo
 import com.superwall.sdk.models.triggers.TriggerResult
 import com.superwall.sdk.paywall.presentation.PaywallInfo
+import com.superwall.sdk.paywall.view.webview.messaging.PageViewData
 import com.superwall.sdk.paywall.presentation.internal.PaywallPresentationRequestStatus
 import com.superwall.sdk.paywall.presentation.internal.PaywallPresentationRequestStatusReason
 import com.superwall.sdk.paywall.view.webview.WebviewError
@@ -136,6 +137,15 @@ sealed class SuperwallEvent {
     ) : SuperwallEvent() {
         override val rawName: String
             get() = "paywall_open"
+    }
+
+    // / When a page view occurs in a multi-page paywall.
+    data class PaywallPageView(
+        val paywallInfo: PaywallInfo,
+        val data: PageViewData,
+    ) : SuperwallEvent() {
+        override val rawName: String
+            get() = SuperwallEvents.PaywallPageView.rawName
     }
 
     // / When a paywall is closed.

--- a/superwall/src/main/java/com/superwall/sdk/analytics/superwall/SuperwallEvents.kt
+++ b/superwall/src/main/java/com/superwall/sdk/analytics/superwall/SuperwallEvents.kt
@@ -65,6 +65,7 @@ enum class SuperwallEvents(
     PermissionDenied("permission_denied"),
     PaywallPreloadStart("paywallPreload_start"),
     PaywallPreloadComplete("paywallPreload_complete"),
+    PaywallPageView("paywall_page_view"),
     TestModeModalOpen("testModeModal_open"),
     TestModeModalClose("testModeModal_close"),
 }

--- a/superwall/src/main/java/com/superwall/sdk/paywall/view/webview/messaging/PageViewData.kt
+++ b/superwall/src/main/java/com/superwall/sdk/paywall/view/webview/messaging/PageViewData.kt
@@ -1,0 +1,12 @@
+package com.superwall.sdk.paywall.view.webview.messaging
+
+data class PageViewData(
+    val pageNodeId: String,
+    val flowPosition: Int,
+    val pageName: String,
+    val navigationNodeId: String,
+    val previousPageNodeId: String?,
+    val previousFlowPosition: Int?,
+    val navigationType: String,
+    val timeOnPreviousPageMs: Int?,
+)

--- a/superwall/src/main/java/com/superwall/sdk/paywall/view/webview/messaging/PaywallMessage.kt
+++ b/superwall/src/main/java/com/superwall/sdk/paywall/view/webview/messaging/PaywallMessage.kt
@@ -11,6 +11,7 @@ import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.booleanOrNull
 import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.int
 import kotlinx.serialization.json.intOrNull
 import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
@@ -127,6 +128,10 @@ sealed class PaywallMessage {
         val name: String,
         val behavior: CustomCallbackBehavior,
         val variables: Map<String, Any>?,
+    ) : PaywallMessage()
+
+    data class PageView(
+        val data: PageViewData,
     ) : PaywallMessage()
 
     data class HapticFeedback(
@@ -255,6 +260,20 @@ private fun parsePaywallMessage(json: JsonObject): PaywallMessage {
                 requestId = requestId,
             )
         }
+
+        "page_view" ->
+            PaywallMessage.PageView(
+                PageViewData(
+                    pageNodeId = json["page_node_id"]!!.jsonPrimitive.content,
+                    flowPosition = json["flow_position"]!!.jsonPrimitive.int,
+                    pageName = json["page_name"]!!.jsonPrimitive.content,
+                    navigationNodeId = json["navigation_node_id"]!!.jsonPrimitive.content,
+                    previousPageNodeId = json["previous_page_node_id"]?.jsonPrimitive?.contentOrNull,
+                    previousFlowPosition = json["previous_flow_position"]?.jsonPrimitive?.intOrNull,
+                    navigationType = json["type"]!!.jsonPrimitive.content,
+                    timeOnPreviousPageMs = json["time_on_previous_page_ms"]?.jsonPrimitive?.intOrNull,
+                ),
+            )
 
         "haptic_feedback" -> {
             val style =

--- a/superwall/src/main/java/com/superwall/sdk/paywall/view/webview/messaging/PaywallMessageHandler.kt
+++ b/superwall/src/main/java/com/superwall/sdk/paywall/view/webview/messaging/PaywallMessageHandler.kt
@@ -264,6 +264,18 @@ class PaywallMessageHandler(
 
             is PaywallMessage.HapticFeedback -> triggerHapticFeedback(message.hapticType)
 
+            is PaywallMessage.PageView -> {
+                val paywallInfo = messageHandler?.state?.info ?: return
+                ioScope.launch {
+                    track(
+                        InternalSuperwallEvent.PaywallPageView(
+                            paywallInfo = paywallInfo,
+                            data = message.data,
+                        ),
+                    )
+                }
+            }
+
             else -> {
                 Logger.debug(
                     LogLevel.error,

--- a/superwall/src/test/java/com/superwall/sdk/analytics/internal/trackable/InternalSuperwallEventTest.kt
+++ b/superwall/src/test/java/com/superwall/sdk/analytics/internal/trackable/InternalSuperwallEventTest.kt
@@ -995,6 +995,94 @@ class InternalSuperwallEventTest {
         return StoreTransaction(transaction, configRequestId = "config", appSessionId = "session")
     }
 
+    @Test
+    fun paywallPageView_allFieldsMappedToSnakeCase() =
+        runTest {
+            Given("a PaywallPageView event with all fields") {
+                val paywallInfo = stubPaywallInfo()
+                val data =
+                    com.superwall.sdk.paywall.view.webview.messaging.PageViewData(
+                        pageNodeId = "node-123",
+                        flowPosition = 2,
+                        pageName = "Pricing",
+                        navigationNodeId = "nav-456",
+                        previousPageNodeId = "node-000",
+                        previousFlowPosition = 1,
+                        navigationType = "forward",
+                        timeOnPreviousPageMs = 3500,
+                    )
+                val event =
+                    InternalSuperwallEvent.PaywallPageView(
+                        paywallInfo = paywallInfo,
+                        data = data,
+                    )
+
+                When("parameters are requested") {
+                    val params = event.getSuperwallParameters()
+
+                    Then("all page view fields are mapped to snake_case keys") {
+                        assertEquals("node-123", params["page_node_id"])
+                        assertEquals(2, params["flow_position"])
+                        assertEquals("Pricing", params["page_name"])
+                        assertEquals("nav-456", params["navigation_node_id"])
+                        assertEquals("forward", params["navigation_type"])
+                        assertEquals("node-000", params["previous_page_node_id"])
+                        assertEquals(1, params["previous_flow_position"])
+                        assertEquals(3500, params["time_on_previous_page_ms"])
+                    }
+
+                    And("paywall info params are also included") {
+                        assertEquals(paywallInfo.identifier, params["paywall_identifier"])
+                    }
+
+                    And("the superwall placement is paywall_page_view") {
+                        assertEquals("paywall_page_view", event.superwallPlacement.rawName)
+                    }
+                }
+            }
+        }
+
+    @Test
+    fun paywallPageView_optionalFieldsOmitted() =
+        runTest {
+            Given("a PaywallPageView event without optional fields") {
+                val paywallInfo = stubPaywallInfo()
+                val data =
+                    com.superwall.sdk.paywall.view.webview.messaging.PageViewData(
+                        pageNodeId = "node-first",
+                        flowPosition = 0,
+                        pageName = "Welcome",
+                        navigationNodeId = "nav-001",
+                        previousPageNodeId = null,
+                        previousFlowPosition = null,
+                        navigationType = "entry",
+                        timeOnPreviousPageMs = null,
+                    )
+                val event =
+                    InternalSuperwallEvent.PaywallPageView(
+                        paywallInfo = paywallInfo,
+                        data = data,
+                    )
+
+                When("parameters are requested") {
+                    val params = event.getSuperwallParameters()
+
+                    Then("required fields are present") {
+                        assertEquals("node-first", params["page_node_id"])
+                        assertEquals(0, params["flow_position"])
+                        assertEquals("Welcome", params["page_name"])
+                        assertEquals("entry", params["navigation_type"])
+                    }
+
+                    And("optional fields are absent") {
+                        assertFalse(params.containsKey("previous_page_node_id"))
+                        assertFalse(params.containsKey("previous_flow_position"))
+                        assertFalse(params.containsKey("time_on_previous_page_ms"))
+                    }
+                }
+            }
+        }
+
     private object NoopPresentationFactory : InternalSuperwallEvent.PresentationRequest.Factory {
         override suspend fun makeRuleAttributes(
             event: EventData?,

--- a/superwall/src/test/java/com/superwall/sdk/paywall/view/webview/PaywallMessageHandlerTest.kt
+++ b/superwall/src/test/java/com/superwall/sdk/paywall/view/webview/PaywallMessageHandlerTest.kt
@@ -15,6 +15,7 @@ import com.superwall.sdk.models.paywall.Paywall
 import com.superwall.sdk.models.product.ProductVariable
 import com.superwall.sdk.paywall.view.PaywallViewState
 import com.superwall.sdk.paywall.view.delegate.PaywallLoadingState
+import com.superwall.sdk.paywall.view.webview.messaging.PageViewData
 import com.superwall.sdk.paywall.view.webview.messaging.PaywallMessage
 import com.superwall.sdk.paywall.view.webview.messaging.PaywallMessageHandler
 import com.superwall.sdk.paywall.view.webview.messaging.PaywallMessageHandlerDelegate
@@ -644,4 +645,173 @@ class PaywallMessageHandlerTest {
             }
         }
     }
+
+    @Test
+    fun parsePageView_allFields() =
+        runTest {
+            Given("a wrapped message containing a page_view event with all fields") {
+                val json =
+                    """
+                {
+                    "version": 1,
+                    "payload": {
+                        "events": [
+                            {
+                                "event_name": "page_view",
+                                "page_node_id": "node-123",
+                                "flow_position": 2,
+                                "page_name": "Pricing",
+                                "navigation_node_id": "nav-456",
+                                "previous_page_node_id": "node-000",
+                                "previous_flow_position": 1,
+                                "type": "forward",
+                                "time_on_previous_page_ms": 3500
+                            }
+                        ]
+                    }
+                }
+                    """.trimIndent()
+
+                When("the message is parsed") {
+                    val result = parseWrappedPaywallMessages(json)
+
+                    Then("it returns a PageView message with correct data") {
+                        assert(result.isSuccess)
+                        val wrapped = result.getOrThrow()
+                        assertEquals(1, wrapped.payload.messages.size)
+                        val message = wrapped.payload.messages[0]
+                        assert(message is PaywallMessage.PageView)
+                        val pageView = (message as PaywallMessage.PageView).data
+                        assertEquals("node-123", pageView.pageNodeId)
+                        assertEquals(2, pageView.flowPosition)
+                        assertEquals("Pricing", pageView.pageName)
+                        assertEquals("nav-456", pageView.navigationNodeId)
+                        assertEquals("node-000", pageView.previousPageNodeId)
+                        assertEquals(1, pageView.previousFlowPosition)
+                        assertEquals("forward", pageView.navigationType)
+                        assertEquals(3500, pageView.timeOnPreviousPageMs)
+                    }
+                }
+            }
+        }
+
+    @Test
+    fun parsePageView_optionalFieldsNull() =
+        runTest {
+            Given("a wrapped message containing a page_view event without optional fields") {
+                val json =
+                    """
+                {
+                    "version": 1,
+                    "payload": {
+                        "events": [
+                            {
+                                "event_name": "page_view",
+                                "page_node_id": "node-first",
+                                "flow_position": 0,
+                                "page_name": "Welcome",
+                                "navigation_node_id": "nav-001",
+                                "type": "entry"
+                            }
+                        ]
+                    }
+                }
+                    """.trimIndent()
+
+                When("the message is parsed") {
+                    val result = parseWrappedPaywallMessages(json)
+
+                    Then("optional fields are null") {
+                        assert(result.isSuccess)
+                        val pageView = (result.getOrThrow().payload.messages[0] as PaywallMessage.PageView).data
+                        assertEquals("node-first", pageView.pageNodeId)
+                        assertEquals(0, pageView.flowPosition)
+                        assertEquals("Welcome", pageView.pageName)
+                        assertEquals("entry", pageView.navigationType)
+                        assertEquals(null, pageView.previousPageNodeId)
+                        assertEquals(null, pageView.previousFlowPosition)
+                        assertEquals(null, pageView.timeOnPreviousPageMs)
+                    }
+                }
+            }
+        }
+
+    @Test
+    fun handlePageView_tracksInternalEvent() =
+        runTest {
+            Given("a PaywallMessageHandler with a delegate") {
+                val paywall = Paywall.stub()
+                val state = PaywallViewState(paywall = paywall, locale = "en-US")
+                val delegate = FakeDelegate(state)
+                val trackedEvents =
+                    mutableListOf<com.superwall.sdk.analytics.internal.trackable.TrackableSuperwallEvent>()
+                val handler =
+                    createHandler(
+                        track = { event -> trackedEvents.add(event) },
+                    )
+                handler.messageHandler = delegate
+
+                When("a PageView message is handled") {
+                    handler.handle(
+                        PaywallMessage.PageView(
+                            PageViewData(
+                                pageNodeId = "node-abc",
+                                flowPosition = 1,
+                                pageName = "Checkout",
+                                navigationNodeId = "nav-xyz",
+                                previousPageNodeId = "node-prev",
+                                previousFlowPosition = 0,
+                                navigationType = "forward",
+                                timeOnPreviousPageMs = 2000,
+                            ),
+                        ),
+                    )
+                    advanceUntilIdle()
+
+                    Then("a PaywallPageView event is tracked") {
+                        assertEquals(1, trackedEvents.size)
+                        val event =
+                            trackedEvents[0]
+                                as com.superwall.sdk.analytics.internal.trackable.InternalSuperwallEvent.PaywallPageView
+                        assertEquals("node-abc", event.data.pageNodeId)
+                        assertEquals(1, event.data.flowPosition)
+                        assertEquals("Checkout", event.data.pageName)
+                        assertEquals("forward", event.data.navigationType)
+                        assertEquals(2000, event.data.timeOnPreviousPageMs)
+                    }
+                }
+            }
+        }
+
+    @Test
+    fun parsePageView_missingRequiredField_fails() =
+        runTest {
+            Given("a wrapped message with page_view missing required page_node_id") {
+                val json =
+                    """
+                {
+                    "version": 1,
+                    "payload": {
+                        "events": [
+                            {
+                                "event_name": "page_view",
+                                "flow_position": 0,
+                                "page_name": "Welcome",
+                                "navigation_node_id": "nav-001",
+                                "type": "entry"
+                            }
+                        ]
+                    }
+                }
+                    """.trimIndent()
+
+                When("the message is parsed") {
+                    val result = parseWrappedPaywallMessages(json)
+
+                    Then("parsing fails") {
+                        assert(result.isFailure)
+                    }
+                }
+            }
+        }
 }


### PR DESCRIPTION
## Changes in this pull request

-

### Checklist

- [ ] All unit tests pass.
- [ ] All UI tests pass.
- [ ] Demo project builds and runs.
- [ ] I added/updated tests or detailed why my change isn't tested.
- [ ] I added an entry to the `CHANGELOG.md` for any breaking changes, enhancements, or bug fixes.
- [ ] I have run `ktlint` in the main directory and fixed any issues.
- [ ] I have updated the SDK documentation as well as the online docs.
- [ ] I have reviewed the [contributing guide](https://github.com/superwall/Superwall-Android/tree/master/.github/CONTRIBUTING.md)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds onboarding/multi-page paywall analytics support by introducing a new `paywall_page_view` event fired whenever the user navigates between pages in a multi-step paywall. The implementation is end-to-end: a new `PageViewData` model, a `page_view` WebView message type, an internal `PaywallPageView` trackable event, and a public `SuperwallEvent.PaywallPageView` — all backed by solid tests.

Key changes:
- `PageViewData` — new data class capturing page node IDs, flow position, navigation type, and optional timing info
- `PaywallMessage.PageView` — parsed from the JS bridge; required fields are guarded with `!!`, optional ones use safe access
- `PaywallMessageHandler` — dispatches `InternalSuperwallEvent.PaywallPageView` on the IO scope, consistent with existing event tracking patterns
- `SuperwallEvent.PaywallPageView` / `SuperwallEvents.PaywallPageView` — public and enum entries wired correctly
- Tests — four integration-style tests covering all-fields, optional-null, handler tracking, and missing-required-field failure paths

Minor concerns to address before merging:
- Import ordering in `TrackableSuperwallEvent.kt` and `SuperwallEvent.kt` splits alphabetical groups and will likely fail `ktlint`
- The `navigationType` field is mapped from the JSON key `"type"` rather than the expected `"navigation_type"`, inconsistent with every other field in the same struct
- `PageViewData` is placed in `paywall.view.webview.messaging` (an internal package) but is exposed via the public `SuperwallEvent.PaywallPageView`; consider relocating it to a presentation/model package

<h3>Confidence Score: 5/5</h3>

Safe to merge; all remaining findings are P2 style/design suggestions with no correctness impact.

The implementation is correct, follows existing patterns, and is well-tested. The three open findings are all P2: import ordering (purely cosmetic/ktlint), the "type" vs "navigation_type" JSON key (works correctly if it matches the JS contract), and the PageViewData package placement (a design preference). None affect runtime behaviour.

Import ordering in TrackableSuperwallEvent.kt and SuperwallEvent.kt should be fixed before ktlint runs.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| superwall/src/main/java/com/superwall/sdk/paywall/view/webview/messaging/PageViewData.kt | New data class for page-view analytics payload; clean structure with appropriate nullability. `timeOnPreviousPageMs` as `Int?` is fine for page-dwell durations. |
| superwall/src/main/java/com/superwall/sdk/paywall/view/webview/messaging/PaywallMessage.kt | Adds `PageView` message type and parses it from JSON; required field handling is consistent with other messages, but `navigationType` is mapped from the generic JSON key `"type"` rather than the expected `"navigation_type"`. |
| superwall/src/main/java/com/superwall/sdk/paywall/view/webview/messaging/PaywallMessageHandler.kt | Handles the new `PageView` message by tracking an `InternalSuperwallEvent.PaywallPageView` on the IO scope; follows existing patterns correctly. |
| superwall/src/main/java/com/superwall/sdk/analytics/internal/trackable/TrackableSuperwallEvent.kt | Adds `PaywallPageView` internal event with correct parameter mapping; import ordering for `PageViewData` breaks the alphabetical grouping of `analytics.superwall` imports. |
| superwall/src/main/java/com/superwall/sdk/analytics/superwall/SuperwallEvent.kt | Adds public `PaywallPageView` event; exposes `PageViewData` from an internal webview package in the public API surface, and has an out-of-order import. |
| superwall/src/main/java/com/superwall/sdk/analytics/superwall/SuperwallEvents.kt | Adds `PaywallPageView("paywall_page_view")` enum entry in the correct position; no issues. |
| superwall/src/test/java/com/superwall/sdk/analytics/internal/trackable/InternalSuperwallEventTest.kt | Two well-structured tests covering all-fields and optional-fields-absent scenarios for the new event; assertions are thorough. |
| superwall/src/test/java/com/superwall/sdk/paywall/view/webview/PaywallMessageHandlerTest.kt | Four tests covering all-fields parsing, optional-fields null, handler integration, and missing-required-field failure; good coverage of the new behaviour. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant JS as Paywall JS (WebView)
    participant MH as PaywallMessageHandler
    participant MQ as parseWrappedPaywallMessages
    participant ISE as InternalSuperwallEvent.PaywallPageView
    participant T as track()
    participant SE as SuperwallEvent.PaywallPageView

    JS->>MH: postMessage(json with event_name="page_view")
    MH->>MQ: parseWrappedPaywallMessages(json)
    MQ-->>MH: Result containing PageView(PageViewData)
    MH->>MH: handle(PaywallMessage.PageView)
    MH->>MH: messageHandler?.state?.info (get PaywallInfo)
    MH->>ISE: PaywallPageView(paywallInfo, data)
    MH->>T: ioScope.launch { track(event) }
    T->>SE: SuperwallEvent.PaywallPageView emitted to delegate
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: superwall/src/main/java/com/superwall/sdk/analytics/internal/trackable/TrackableSuperwallEvent.kt
Line: 1-4

Comment:
**Import ordering breaks ktlint grouping**

`PageViewData` is inserted between two `analytics.superwall` imports, splitting what should be a contiguous alphabetical group. This will likely fail `ktlint`. The same issue occurs in `SuperwallEvent.kt` (lines 8-9), where `paywall.view.webview.messaging.PageViewData` precedes `paywall.presentation.internal.*` imports out of alphabetical order.

```suggestion
package com.superwall.sdk.analytics.internal.trackable

import com.superwall.sdk.analytics.superwall.SuperwallEvent
import com.superwall.sdk.analytics.superwall.TransactionProduct
import com.superwall.sdk.paywall.view.webview.messaging.PageViewData
```

In `SuperwallEvent.kt`, move the `PageViewData` import after the `PaywallInfo` import and before `PaywallPresentationRequestStatus` to maintain alphabetical ordering within the `paywall.*` group.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: superwall/src/main/java/com/superwall/sdk/paywall/view/webview/messaging/PaywallMessage.kt
Line: 273

Comment:
**JSON key `"type"` is inconsistent with field name `navigationType`**

Every other field in `PageViewData` maps directly from a snake_case JSON key that matches its Kotlin name (e.g. `navigation_node_id` → `navigationNodeId`), but `navigationType` maps from the ambiguous generic key `"type"`. This deviates from the established convention and is easy to misread.

If the upstream JS contract really sends `"type"`, consider documenting this explicitly, or (if the contract can be changed) align it to `"navigation_type"`.

```suggestion
                    navigationType = json["navigation_type"]!!.jsonPrimitive.content,
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: superwall/src/main/java/com/superwall/sdk/analytics/superwall/SuperwallEvent.kt
Line: 143-149

Comment:
**`PageViewData` is a public API type from an internal package**

`SuperwallEvent.PaywallPageView` is part of the SDK's public surface, but its `data` parameter is typed as `PageViewData` from `com.superwall.sdk.paywall.view.webview.messaging` — an implementation-detail package. SDK consumers using this event via `SuperwallDelegate` will need to import from the webview messaging internals.

Consider moving `PageViewData` to a more appropriate location (e.g. alongside `PaywallInfo` in `paywall.presentation`) or to a dedicated model package so the public API doesn't expose an internal layer.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Add onboarding analytics support"](https://github.com/superwall/superwall-android/commit/7d63808265000742e5b76de332d3fe020beb9873) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27023498)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->