### PR TITLE
Improve exponential backoff retry for unavailable play services

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ The changelog for `Superwall`. Also see the [releases](https://github.com/superw
 ## Fixes
 
 - Fixes test mode products not being loaded properly in PW
+- Improve exponential backoff retry for Play Service unavailable
+- Fix Custom Info date serialization issues
 
 ## 2.7.13
 

--- a/superwall/src/main/java/com/superwall/sdk/billing/BillingClientUseCase.kt
+++ b/superwall/src/main/java/com/superwall/sdk/billing/BillingClientUseCase.kt
@@ -14,6 +14,8 @@ internal typealias ExecuteRequestOnUIThreadFunction = (delayInMillis: Long, onEr
 private const val MAX_RETRIES_DEFAULT = 3
 private const val RETRY_TIMER_START_MILLISECONDS = 878L // So it gets close to 15 minutes in last retry
 internal const val RETRY_TIMER_MAX_TIME_MILLISECONDS = 1000L * 60L * 15L // 15 minutes
+private const val FOREGROUND_BACKOFF_START_MILLISECONDS = 250L
+private const val FOREGROUND_BACKOFF_MAX_ATTEMPTS = 2
 
 internal interface UseCaseParams {
     val appInBackground: Boolean
@@ -33,6 +35,7 @@ internal abstract class BillingClientUseCase<T>(
     private val maxRetries: Int = MAX_RETRIES_DEFAULT
     private var retryAttempt: Int = 0
     private var retryBackoffMilliseconds = RETRY_TIMER_START_MILLISECONDS
+    private var foregroundBackoffAttempt: Int = 0
 
     fun run(delayMilliseconds: Long = 0) {
         executeRequestOnUIThread(delayMilliseconds) { connectionError ->
@@ -144,11 +147,28 @@ internal abstract class BillingClientUseCase<T>(
             } else {
                 onError(billingResult)
             }
+        } else if (retryAttempt < maxRetries) {
+            Logger.debug(
+                logLevel = LogLevel.warn,
+                scope = LogScope.productsManager,
+                message = "Billing unavailable in foreground. Retry ${retryAttempt + 1}/$maxRetries (immediate).",
+            )
+            retryAttempt++
+            executeAsync()
+        } else if (foregroundBackoffAttempt < FOREGROUND_BACKOFF_MAX_ATTEMPTS) {
+            val delay = FOREGROUND_BACKOFF_START_MILLISECONDS shl foregroundBackoffAttempt
+            Logger.debug(
+                logLevel = LogLevel.warn,
+                scope = LogScope.productsManager,
+                message = "Billing unavailable in foreground. Backoff retry ${foregroundBackoffAttempt + 1}/$FOREGROUND_BACKOFF_MAX_ATTEMPTS in ${delay}ms.",
+            )
+            foregroundBackoffAttempt++
+            run(delay)
         } else {
             Logger.debug(
                 logLevel = LogLevel.error,
                 scope = LogScope.productsManager,
-                message = "Billing is unavailable. App is in foreground. Won't retry.",
+                message = "Billing unavailable. Foreground retries exhausted.",
             )
             onError(billingResult)
         }

--- a/superwall/src/main/java/com/superwall/sdk/models/customer/CustomerInfo.kt
+++ b/superwall/src/main/java/com/superwall/sdk/models/customer/CustomerInfo.kt
@@ -3,6 +3,7 @@ package com.superwall.sdk.models.customer
 import com.superwall.sdk.models.entitlements.Entitlement
 import com.superwall.sdk.models.entitlements.SubscriptionStatus
 import com.superwall.sdk.models.product.Store
+import com.superwall.sdk.network.JsonFactory
 import com.superwall.sdk.storage.LatestDeviceCustomerInfo
 import com.superwall.sdk.storage.LatestRedemptionResponse
 import com.superwall.sdk.storage.Storage
@@ -10,8 +11,6 @@ import com.superwall.sdk.storage.core_data.convertFromJsonElement
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.Transient
-import kotlinx.serialization.json.Json
-import kotlinx.serialization.json.JsonNamingStrategy
 import kotlinx.serialization.json.jsonObject
 
 /**
@@ -58,7 +57,7 @@ data class CustomerInfo(
      */
     fun toParams(): Map<String, Any?> {
         if (isPlaceholder) return emptyMap()
-        val obj = paramsJson.encodeToJsonElement(serializer(), this).jsonObject
+        val obj = JsonFactory.JSON.encodeToJsonElement(serializer(), this).jsonObject
         return obj
             .mapValues { (_, value) -> value.convertFromJsonElement() }
     }
@@ -87,16 +86,6 @@ data class CustomerInfo(
         }
 
     companion object {
-        private val paramsJson = Json {
-            try {
-
-                namingStrategy = JsonNamingStrategy.SnakeCase
-            } catch (e: Throwable) {
-            }
-            encodeDefaults = true;
-            ignoreUnknownKeys = true
-        }
-
         /**
          * Creates a blank CustomerInfo instance for testing or default states.
          */


### PR DESCRIPTION
## Changes in this pull request

- 

### Checklist

- [ ] All unit tests pass.
- [ ] All UI tests pass.
- [ ] Demo project builds and runs.
- [ ] I added/updated tests or detailed why my change isn't tested.
- [ ] I added an entry to the `CHANGELOG.md` for any breaking changes, enhancements, or bug fixes.
- [ ] I have run `ktlint` in the main directory and fixed any issues.
- [ ] I have updated the SDK documentation as well as the online docs.
- [ ] I have reviewed the [contributing guide](https://github.com/superwall/Superwall-Android/tree/master/.github/CONTRIBUTING.md)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR improves billing resilience when Play Services are unavailable in the foreground and fixes `CustomerInfo` date serialization by switching to the shared `JsonFactory.JSON` instance.

- **`BillingClientUseCase`**: Introduces a two-stage foreground retry strategy for `SERVICE_UNAVAILABLE`: up to 3 immediate retries (via `retryAttempt`) followed by 2 exponential backoff retries (250 ms → 500 ms via `foregroundBackoffAttempt`), replacing the previous behaviour of immediately calling `onError` in the foreground.
- **`CustomerInfo.toParams()`**: Removes the local `paramsJson` instance (which lacked the `DateSerializer` contextual module) and replaces it with `JsonFactory.JSON`, which carries the correct serializers module and snake_case naming strategy, fixing date serialization in template/analytics parameters.

<h3>Confidence Score: 3/5</h3>

Safe to merge with minor counter-sharing concern in the billing retry logic that could silently reduce the effective retry budget under mixed error conditions.

The `retryAttempt` counter is now shared between the `NETWORK_ERROR` path and the new `SERVICE_UNAVAILABLE` foreground path. A request that first hits a few network errors will have a smaller immediate-retry budget left when it later encounters `SERVICE_UNAVAILABLE`, with no visible indication to the caller. Additionally, neither `retryAttempt` nor `foregroundBackoffAttempt` is reset when a response returns `OK`, leaving the instance in a partially-spent state. The `CustomerInfo` fix is straightforward and correct.

`BillingClientUseCase.kt` warrants a second look around the shared `retryAttempt` counter and the on-success reset logic.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| superwall/src/main/java/com/superwall/sdk/billing/BillingClientUseCase.kt | Adds two-stage foreground retry for SERVICE_UNAVAILABLE: 3 immediate retries then 2 exponential backoff retries (250 ms, 500 ms); shares `retryAttempt` counter with the network-error path and does not reset counters on success, which can silently reduce the effective retry budget. |
| superwall/src/main/java/com/superwall/sdk/models/customer/CustomerInfo.kt | Replaces the locally-defined `paramsJson` (missing DateSerializer) with the shared `JsonFactory.JSON`, fixing date serialization in `toParams()`; change is clean and correct. |
| CHANGELOG.md | Adds two changelog entries for the improvements made in this PR; no issues. |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[processResult: SERVICE_UNAVAILABLE] --> B{appInBackground?}
    B -- Yes --> C{retryBackoffMilliseconds < 15min?}
    C -- Yes --> D[retryWithBackoff: exponential delay, run]
    C -- No --> E[onError]
    B -- No --> F{retryAttempt < maxRetries=3?}
    F -- Yes --> G[retryAttempt++, executeAsync immediate]
    G --> A
    F -- No --> H{foregroundBackoffAttempt < 2?}
    H -- Yes --> I["delay = 250ms shl foregroundBackoffAttempt\nforegroundBackoffAttempt++\nrun(delay)"]
    I --> A
    H -- No --> J[onError: foreground retries exhausted]
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `superwall/src/main/java/com/superwall/sdk/billing/BillingClientUseCase.kt`, line 60-63 ([link](https://github.com/superwall/superwall-android/blob/1ce8e39a1a41c8eb52e3ddd01ad0a02c15588a5f/superwall/src/main/java/com/superwall/sdk/billing/BillingClientUseCase.kt#L60-L63)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Retry counters not reset on success**

   When a response is `OK`, only `retryBackoffMilliseconds` is reset to `RETRY_TIMER_START_MILLISECONDS`. Both `retryAttempt` and `foregroundBackoffAttempt` keep their accumulated values. If a use-case instance is ever reused after a successful response (e.g., the same instance is run again for a follow-up request), the retry and backoff budgets will already be partially or fully spent. If instances are always discarded on success this is a no-op, but resetting all three counters here would make the state management self-consistent.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: superwall/src/main/java/com/superwall/sdk/billing/BillingClientUseCase.kt
   Line: 60-63

   Comment:
   **Retry counters not reset on success**

   When a response is `OK`, only `retryBackoffMilliseconds` is reset to `RETRY_TIMER_START_MILLISECONDS`. Both `retryAttempt` and `foregroundBackoffAttempt` keep their accumulated values. If a use-case instance is ever reused after a successful response (e.g., the same instance is run again for a follow-up request), the retry and backoff budgets will already be partially or fully spent. If instances are always discarded on success this is a no-op, but resetting all three counters here would make the state management self-consistent.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
superwall/src/main/java/com/superwall/sdk/billing/BillingClientUseCase.kt:150-157
**`retryAttempt` shared with network-error path**

`retryAttempt` is also incremented in `backoffOrRetryNetworkError` (for `NETWORK_ERROR`/`ERROR` codes). If the same use-case instance first encounters a `NETWORK_ERROR` (e.g. 2 times), and then later encounters `SERVICE_UNAVAILABLE` while in the foreground, only 1 immediate retry remains out of the expected 3. A separate counter for `SERVICE_UNAVAILABLE` foreground retries (similar to `foregroundBackoffAttempt`) would isolate the budgets and make the behaviour more predictable.

### Issue 2 of 2
superwall/src/main/java/com/superwall/sdk/billing/BillingClientUseCase.kt:60-63
**Retry counters not reset on success**

When a response is `OK`, only `retryBackoffMilliseconds` is reset to `RETRY_TIMER_START_MILLISECONDS`. Both `retryAttempt` and `foregroundBackoffAttempt` keep their accumulated values. If a use-case instance is ever reused after a successful response (e.g., the same instance is run again for a follow-up request), the retry and backoff budgets will already be partially or fully spent. If instances are always discarded on success this is a no-op, but resetting all three counters here would make the state management self-consistent.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Improve exponential backoff retry for un..."](https://github.com/superwall/superwall-android/commit/1ce8e39a1a41c8eb52e3ddd01ad0a02c15588a5f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31572268)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->