### PR TITLE
Fix day↔week price conversion

### DIFF
--- a/superwall/src/main/java/com/superwall/sdk/store/abstractions/product/RawStoreProduct.kt
+++ b/superwall/src/main/java/com/superwall/sdk/store/abstractions/product/RawStoreProduct.kt
@@ -684,7 +684,8 @@ class RawStoreProduct(
             SubscriptionPeriod.Unit.day -> {
                 when (trialSubscriptionPeriod?.unit) {
                     SubscriptionPeriod.Unit.day -> BigDecimal(1)
-                    SubscriptionPeriod.Unit.week -> BigDecimal(365).divide(BigDecimal(52), 6, RoundingMode.DOWN)
+                    // 7 days per week exactly — not 365/52.
+                    SubscriptionPeriod.Unit.week -> BigDecimal(7)
                     SubscriptionPeriod.Unit.month -> BigDecimal(365).divide(BigDecimal(12), 6, RoundingMode.DOWN)
                     SubscriptionPeriod.Unit.year -> BigDecimal(365)
                     else -> BigDecimal.ZERO
@@ -693,9 +694,10 @@ class RawStoreProduct(
 
             SubscriptionPeriod.Unit.week -> {
                 when (trialSubscriptionPeriod?.unit) {
+                    // A day is exactly 1/7 of a week — not 52/365.
                     SubscriptionPeriod.Unit.day ->
-                        BigDecimal(52).divide(
-                            BigDecimal(365),
+                        BigDecimal.ONE.divide(
+                            BigDecimal(7),
                             6,
                             RoundingMode.DOWN,
                         )

--- a/superwall/src/main/java/com/superwall/sdk/store/abstractions/product/SubscriptionPeriod.kt
+++ b/superwall/src/main/java/com/superwall/sdk/store/abstractions/product/SubscriptionPeriod.kt
@@ -106,7 +106,10 @@ data class SubscriptionPeriod(
         val periodsPerDay: BigDecimal =
             when (this.unit) {
                 Unit.day -> BigDecimal.ONE
-                Unit.week -> BigDecimal(365).divide(BigDecimal(52), calculationScale, roundingMode)
+                // A week is exactly 7 days. Don't route through 365/52 — 52
+                // weeks is only 364 days, so that approximation makes a
+                // weekly product's daily price a cent off.
+                Unit.week -> BigDecimal(7)
                 Unit.month -> BigDecimal(365).divide(BigDecimal(12), calculationScale, roundingMode)
                 Unit.year -> BigDecimal(365)
             } * BigDecimal(this.value)
@@ -117,7 +120,9 @@ data class SubscriptionPeriod(
     fun pricePerWeek(price: BigDecimal): BigDecimal {
         val periodsPerWeek: BigDecimal =
             when (this.unit) {
-                Unit.day -> BigDecimal(52).divide(BigDecimal(365), calculationScale, roundingMode)
+                // A day is exactly 1/7 of a week. The old 52/365 made a 7-day
+                // product resolve to 0.997 weeks, inflating its weekly price.
+                Unit.day -> BigDecimal.ONE.divide(BigDecimal(7), calculationScale, roundingMode)
                 Unit.week -> BigDecimal.ONE
                 Unit.month -> BigDecimal(52).divide(BigDecimal(12), calculationScale, roundingMode)
                 Unit.year -> BigDecimal(52)

--- a/superwall/src/test/java/com/superwall/sdk/store/abstractions/product/SubscriptionPeriodUnitTest.kt
+++ b/superwall/src/test/java/com/superwall/sdk/store/abstractions/product/SubscriptionPeriodUnitTest.kt
@@ -30,6 +30,26 @@ class SubscriptionPeriodUnitTest {
         println(res)
         assert(res == SubscriptionPeriod(31, SubscriptionPeriod.Unit.day))
     }
+
+    // A 7-day period is exactly one week, so its weekly price must equal the
+    // price. Before the day↔week fix this divided by (7 × 52/365) ≈ 0.997,
+    // inflating it (e.g. 6.99 → 7.00).
+    @Test
+    fun sevenDayPeriod_weeklyPriceEqualsPrice() {
+        val period = SubscriptionPeriod(7, SubscriptionPeriod.Unit.day)
+        val pricePerWeek = period.pricePerWeek(BigDecimal(6.99))
+        assert(pricePerWeek.compareTo(truncateDecimal(BigDecimal(6.99), 2)) == 0)
+    }
+
+    // A week is exactly 7 days. Before the fix, pricePerDay for a week product
+    // divided by 365/52 ≈ 7.019, so a $7.00/week product reported $0.99/day
+    // instead of the exact $1.00.
+    @Test
+    fun weeklyPeriod_dailyPriceDividesBySeven() {
+        val period = SubscriptionPeriod(1, SubscriptionPeriod.Unit.week)
+        val pricePerDay = period.pricePerDay(BigDecimal(7.00))
+        assert(pricePerDay.compareTo(truncateDecimal(BigDecimal(1.00), 2)) == 0)
+    }
 /* TODO: Re-enable these in CI
     @Test
     fun singleDaily_isCorrect() {

--- a/superwall/src/test/java/com/superwall/sdk/store/abstractions/product/SubscriptionPeriodUnitTest.kt
+++ b/superwall/src/test/java/com/superwall/sdk/store/abstractions/product/SubscriptionPeriodUnitTest.kt
@@ -1,5 +1,6 @@
 package com.superwall.sdk.store.abstractions.product
 
+import org.junit.Assert.assertEquals
 import org.junit.Test
 import java.math.BigDecimal
 
@@ -34,11 +35,13 @@ class SubscriptionPeriodUnitTest {
     // A 7-day period is exactly one week, so its weekly price must equal the
     // price. Before the day↔week fix this divided by (7 × 52/365) ≈ 0.997,
     // inflating it (e.g. 6.99 → 7.00).
+    // BigDecimal(String) — the double constructor would store an inexact
+    // binary value. assertEquals — Kotlin's assert() is a no-op without -ea.
     @Test
     fun sevenDayPeriod_weeklyPriceEqualsPrice() {
         val period = SubscriptionPeriod(7, SubscriptionPeriod.Unit.day)
-        val pricePerWeek = period.pricePerWeek(BigDecimal(6.99))
-        assert(pricePerWeek.compareTo(truncateDecimal(BigDecimal(6.99), 2)) == 0)
+        val pricePerWeek = period.pricePerWeek(BigDecimal("6.99"))
+        assertEquals(0, pricePerWeek.compareTo(BigDecimal("6.99")))
     }
 
     // A week is exactly 7 days. Before the fix, pricePerDay for a week product
@@ -47,8 +50,8 @@ class SubscriptionPeriodUnitTest {
     @Test
     fun weeklyPeriod_dailyPriceDividesBySeven() {
         val period = SubscriptionPeriod(1, SubscriptionPeriod.Unit.week)
-        val pricePerDay = period.pricePerDay(BigDecimal(7.00))
-        assert(pricePerDay.compareTo(truncateDecimal(BigDecimal(1.00), 2)) == 0)
+        val pricePerDay = period.pricePerDay(BigDecimal("7.00"))
+        assertEquals(0, pricePerDay.compareTo(BigDecimal("1.00")))
     }
 /* TODO: Re-enable these in CI
     @Test


### PR DESCRIPTION
## Summary

Android counterpart to the iOS SDK fix (superwall/Superwall-iOS#473) and the editor fix (superwall/paywall-next#3178).

`SubscriptionPeriod` converted between days and weeks via a `52/365` factor — but 52 weeks is only 364 days, so a 7-day period resolved to ~0.997 weeks instead of exactly 1. That inflates a 7-day product's weekly price and skews a week product's daily price (e.g. a `$7.00/week` product reports `$0.99/day` instead of the exact `$1.00`).

7 days is exactly 1 week, so the conversion should be exact.

## Scope note

Android does **not** have the iOS variant of the bug where the price getters bypassed `normalized()` — Android's `RawStoreProduct` price getters already compute off the normalized `SubscriptionPeriod`, and `SubscriptionPeriod.from()` collapses whole-week day-counts to weeks. So the most visible symptom (`weeklyPrice` of a weekly product) does not reproduce on Android. What this fixes is the residual error: `dailyPrice` of weekly products, odd day-count products, and trial per-unit prices — all of which would otherwise disagree with the now-fixed iOS SDK and editor.

## Changes

- **`SubscriptionPeriod.kt`** — `pricePerDay` `.week`: `365/52` → `7`; `pricePerWeek` `.day`: `52/365` → `1/7`.
- **`RawStoreProduct.kt`** — `periodsPerUnit` (trial-price path): the same two day↔week entries.
- Month↔year was already exact (`12`); week↔month / week↔year stay as conventional approximations.

## Tests

Added two regression tests to the **active** test region of `SubscriptionPeriodUnitTest`:
- a 7-day period's `pricePerWeek` equals the price;
- a weekly product's `pricePerDay` divides by exactly 7 (`$7.00/week` → `$1.00/day`, which the old `365/52` got wrong as `$0.99`).

Note: the existing `singleDaily`/`multiDaily`/… period-price tests are still inside the pre-existing `/* TODO: Re-enable these in CI */` block — left untouched (some of them also carry unrelated stale month↔week expectations). 3 tests run, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes the day↔week conversion factor in `SubscriptionPeriod.pricePerDay`/`pricePerWeek` and in `RawStoreProduct.periodsPerUnit`, replacing the approximate `365/52` (≈7.019) and `52/365` (≈0.1425) factors with the exact `7` and `1/7`.

- **`SubscriptionPeriod.kt`**: `pricePerDay` for a weekly product now uses `BigDecimal(7)` (days per week); `pricePerWeek` for a daily product now uses `1/7` (weeks per day).
- **`RawStoreProduct.kt`**: The same two day↔week entries in `periodsPerUnit` are updated to match.
- **`SubscriptionPeriodUnitTest.kt`**: Two new regression tests use `BigDecimal(String)` and `assertEquals` correctly and are placed in the active (non-commented) test region.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a narrow, well-scoped arithmetic correction with no side effects on unrelated paths.

The two changed constants (365/52 → 7 and 52/365 → 1/7) are mathematically exact, applied consistently in both SubscriptionPeriod and RawStoreProduct, and directly verified by two new regression tests that use the correct BigDecimal(String) constructor and assertEquals. Month↔year and week↔month conversions are left untouched as documented conventional approximations.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| superwall/src/main/java/com/superwall/sdk/store/abstractions/product/SubscriptionPeriod.kt | Replaces the approximate 365/52 day↔week factor with the exact value 7 in both pricePerDay (week→days) and pricePerWeek (day→weeks); all other conversions left untouched. |
| superwall/src/main/java/com/superwall/sdk/store/abstractions/product/RawStoreProduct.kt | Mirrors the SubscriptionPeriod fix in periodsPerUnit: day←week now returns BigDecimal(7) and week←day now returns 1/7 instead of the old 52/365 approximation. |
| superwall/src/test/java/com/superwall/sdk/store/abstractions/product/SubscriptionPeriodUnitTest.kt | Adds two regression tests (sevenDayPeriod_weeklyPriceEqualsPrice and weeklyPeriod_dailyPriceDividesBySeven) using the BigDecimal(String) constructor and assertEquals — correctly placed outside the disabled CI block. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[SubscriptionPeriod] --> B{pricePerDay}
    A --> C{pricePerWeek}

    B -->|unit = day| D["÷ 1 × value"]
    B -->|unit = week| E["÷ 7 × value ✅ was: 365÷52"]
    B -->|unit = month| F["÷ 365÷12 × value"]
    B -->|unit = year| G["÷ 365 × value"]

    C -->|unit = day| H["÷ 1÷7 × value ✅ was: 52÷365"]
    C -->|unit = week| I["÷ 1 × value"]
    C -->|unit = month| J["÷ 52÷12 × value"]
    C -->|unit = year| K["÷ 52 × value"]

    L[RawStoreProduct.periodsPerUnit] --> M{outer unit}
    M -->|day| N{trial unit}
    M -->|week| O{trial unit}
    N -->|week| P["7 ✅ was: 365÷52"]
    O -->|day| Q["1÷7 ✅ was: 52÷365"]
```

<sub>Reviews (2): Last reviewed commit: ["Use exact BigDecimal and assertEquals in..."](https://github.com/superwall/superwall-android/commit/e7afc37a1a1b6715c80553ff248993c576aac7f6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32334492)</sub>

<!-- /greptile_comment -->