### PR TITLE
Notify paywall webview on transaction abandon with custom purchase controller

### DIFF
--- a/superwall/src/main/java/com/superwall/sdk/dependencies/DependencyContainer.kt
+++ b/superwall/src/main/java/com/superwall/sdk/dependencies/DependencyContainer.kt
@@ -617,6 +617,18 @@ class DependencyContainer(
                     }
                     paywallView.updateState(state)
                 },
+                notifyOfTransactionAbandon = { key ->
+                    val paywallView =
+                        resolvePaywallViewForKey(
+                            makeViewStore(),
+                            Superwall.instance.paywallView,
+                            key,
+                        )
+                    if (paywallView == null) {
+                        return@TransactionManager
+                    }
+                    paywallView.webView.messageHandler.handle(PaywallMessage.TransactionAbandon)
+                },
                 notifyOfTransactionComplete = { key, trialEndDate, id ->
                     val paywallView =
                         resolvePaywallViewForKey(

--- a/superwall/src/main/java/com/superwall/sdk/paywall/view/webview/messaging/PaywallMessage.kt
+++ b/superwall/src/main/java/com/superwall/sdk/paywall/view/webview/messaging/PaywallMessage.kt
@@ -85,6 +85,8 @@ sealed class PaywallMessage {
 
     object TransactionStart : PaywallMessage()
 
+    object TransactionAbandon : PaywallMessage()
+
     data class TransactionComplete(
         val productIdentifier: String,
     ) : PaywallMessage()

--- a/superwall/src/main/java/com/superwall/sdk/paywall/view/webview/messaging/PaywallMessageHandler.kt
+++ b/superwall/src/main/java/com/superwall/sdk/paywall/view/webview/messaging/PaywallMessageHandler.kt
@@ -216,6 +216,12 @@ class PaywallMessageHandler(
                 }
             }
 
+            is PaywallMessage.TransactionAbandon -> {
+                ioScope.launch {
+                    pass(eventName = SuperwallEvents.TransactionAbandon.rawName, paywall = paywall)
+                }
+            }
+
             is PaywallMessage.UserAttributesUpdated -> {
                 setAttributes(message.data)
             }

--- a/superwall/src/main/java/com/superwall/sdk/store/transactions/TransactionManager.kt
+++ b/superwall/src/main/java/com/superwall/sdk/store/transactions/TransactionManager.kt
@@ -79,6 +79,7 @@ class TransactionManager(
     private val refreshReceipt: () -> Unit,
     private val updateState: (cacheKey: String, update: PaywallViewState.Updates) -> Unit,
     private val notifyOfTransactionComplete: suspend (paywallCacheKey: String, trialEndDate: Long?, productId: String) -> Unit,
+    private val notifyOfTransactionAbandon: suspend (paywallCacheKey: String) -> Unit = {},
     private val testMode: TestMode? = null,
     private val testModeTransactionHandler: TestModeTransactionHandler? = null,
     private val setSubscriptionStatus: ((SubscriptionStatus) -> Unit)? = null,
@@ -729,6 +730,8 @@ class TransactionManager(
                         demandTier = factory.demandTier(),
                     )
                 track(trackedEvent)
+
+                notifyOfTransactionAbandon(paywallInfo.cacheKey)
 
                 updateState(
                     paywallInfo.cacheKey,


### PR DESCRIPTION
## Problem

When a paywall uses a **custom `PurchaseController`** and the user **abandons** a purchase (backs out of the Google Play sheet), the paywall webview is never told the transaction was abandoned. As a result, a purchase button's `onAbandon` actions configured in the paywall editor (e.g. setting a state variable to reveal an exit offer / close button) never run, so the exit UI never appears.

The `transaction_abandon` analytics event *is* tracked, but that is separate from the `paywall_event_receiver` message the webview needs to drive the purchase action's `onAbandon` callbacks.

## Root cause

`TransactionManager.trackCancelled` (the `PurchaseSource.Internal` branch) tracks the abandon event but does not forward a `transaction_abandon` message to the paywall webview. There is also no `TransactionAbandon` case in the Android `PaywallMessage` types.

This works on iOS. In `Superwall-iOS`, `TransactionManager` does both, right after tracking:

```swift
await Superwall.shared.track(transactionAbandon)
await paywallViewController.webView.messageHandler.handle(.transactionAbandon)
```

and iOS `PaywallMessage` includes `transactionStart`, `transactionComplete`, `transactionFail`, `transactionAbandon`, `transactionTimeout`. The Android `PaywallMessage` only has `TransactionStart` and `TransactionComplete`, so the abandon message had no representation and was never sent.

## Fix

Mirror the iOS behaviour:

- Add `PaywallMessage.TransactionAbandon`.
- Handle it in `PaywallMessageHandler` by forwarding `SuperwallEvents.TransactionAbandon.rawName` to the webview (same `pass(...)` path as `TransactionStart`).
- In `DependencyContainer`, wire a `notifyOfTransactionAbandon` lambda that resolves the active paywall view by cache key and posts `PaywallMessage.TransactionAbandon` (mirrors `notifyOfTransactionComplete`).
- Call it from `TransactionManager.trackCancelled` (Internal branch), right after `track(...)`, before resetting the loading state — matching iOS order. The new constructor parameter has a no-op default, so it is non-breaking for existing callers/tests.

## Testing

Reproduced on an emulator with a custom `PurchaseController` (RevenueCat) on a paywall whose purchase button has an `onAbandon` action that sets a state variable bound to a close button's visibility. Before: abandoning the purchase left the exit/close UI hidden. After: the `onAbandon` action runs and the exit offer / close button appears, matching iOS.
