### PR TITLE
[codex] Clarify OneSignal user ID attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The changelog for `Superwall`. Also see the [releases](https://github.com/superw
 ## Enhancements
 
 - Adds `singularDeviceId` as an `AttributionProvider`.
+- Clarifies that `AttributionProvider.ONESIGNAL_ID` should be set to the OneSignal User ID used by the OneSignal integration.
 
 ## 2.7.17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The changelog for `Superwall`. Also see the [releases](https://github.com/superwall/Superwall-Android/releases) on GitHub.
 
+## 2.7.18
+
+## Enhancements
+
+- Adds `singularDeviceId` as an `AttributionProvider`.
+
 ## 2.7.17
 
 ## Fixes

--- a/superwall/src/androidTest/java/com/superwall/sdk/models/attribution/AttributionProviderIntegrationTest.kt
+++ b/superwall/src/androidTest/java/com/superwall/sdk/models/attribution/AttributionProviderIntegrationTest.kt
@@ -76,6 +76,7 @@ class AttributionProviderIntegrationTest {
                             AttributionProvider.MIXPANEL to "mp_distinct_789",
                             AttributionProvider.GOOGLE_ADS to "gclid_abc123",
                             AttributionProvider.ADJUST_ID to "adjust_123",
+                            AttributionProvider.SINGULAR_DEVICE_ID to "singular_device_123",
                             AttributionProvider.AMPLITUDE_DEVICE_ID to "amp_device_456",
                             AttributionProvider.FIREBASE_APP_INSTANCE_ID to "firebase_789",
                             AttributionProvider.CUSTOM to "custom_id_xyz",
@@ -93,10 +94,11 @@ class AttributionProviderIntegrationTest {
                     assertEquals("mp_distinct_789", attributionProps["mixpanel"])
                     assertEquals("gclid_abc123", attributionProps["googleAds"])
                     assertEquals("adjust_123", attributionProps["adjustId"])
+                    assertEquals("singular_device_123", attributionProps["singularDeviceId"])
                     assertEquals("amp_device_456", attributionProps["amplitudeDeviceId"])
                     assertEquals("firebase_789", attributionProps["firebaseAppInstanceId"])
                     assertEquals("custom_id_xyz", attributionProps["custom"])
-                    assertEquals(8, attributionProps.size)
+                    assertEquals(9, attributionProps.size)
                 }
             }
         }
@@ -156,6 +158,7 @@ class AttributionProviderIntegrationTest {
                     val attributionIdentifiers =
                         mapOf(
                             AttributionProvider.ADJUST_ID to "adjust_test_123",
+                            AttributionProvider.SINGULAR_DEVICE_ID to "singular_device_test_123",
                             AttributionProvider.AMPLITUDE_DEVICE_ID to "amp_device_test_456",
                             AttributionProvider.AMPLITUDE_USER_ID to "amp_user_test_789",
                             AttributionProvider.APPSFLYER_ID to "appsflyer_test_abc",
@@ -185,6 +188,7 @@ class AttributionProviderIntegrationTest {
                     val attributionProps = attributionManager.integrationAttributes
 
                     assertEquals("adjust_test_123", attributionProps["adjustId"])
+                    assertEquals("singular_device_test_123", attributionProps["singularDeviceId"])
                     assertEquals("amp_device_test_456", attributionProps["amplitudeDeviceId"])
                     assertEquals("amp_user_test_789", attributionProps["amplitudeUserId"])
                     assertEquals("appsflyer_test_abc", attributionProps["appsflyerId"])
@@ -204,7 +208,7 @@ class AttributionProviderIntegrationTest {
                     assertEquals("tenjin_test_def", attributionProps["tenjinId"])
                     assertEquals("posthog_test_ghi", attributionProps["posthogUserId"])
                     assertEquals("customerio_test_jkl", attributionProps["customerioId"])
-                    assertEquals(20, attributionProps.size)
+                    assertEquals(21, attributionProps.size)
                 }
             }
         }

--- a/superwall/src/main/java/com/superwall/sdk/models/attribution/AttributionProvider.kt
+++ b/superwall/src/main/java/com/superwall/sdk/models/attribution/AttributionProvider.kt
@@ -15,6 +15,10 @@ enum class AttributionProvider(
     @SerialName("adjustId")
     ADJUST_ID("adjustId"),
 
+    /** The Singular Device ID (SDID). */
+    @SerialName("singularDeviceId")
+    SINGULAR_DEVICE_ID("singularDeviceId"),
+
     /** The Amplitude device identifier. */
     @SerialName("amplitudeDeviceId")
     AMPLITUDE_DEVICE_ID("amplitudeDeviceId"),

--- a/superwall/src/main/java/com/superwall/sdk/models/attribution/AttributionProvider.kt
+++ b/superwall/src/main/java/com/superwall/sdk/models/attribution/AttributionProvider.kt
@@ -39,7 +39,7 @@ enum class AttributionProvider(
     @SerialName("brazeAliasLabel")
     BRAZE_ALIAS_LABEL("brazeAliasLabel"),
 
-    /** The OneSignal Player identifier for the user. */
+    /** The OneSignal User ID (`onesignal_id`) for the user. */
     @SerialName("onesignalId")
     ONESIGNAL_ID("onesignalId"),
 


### PR DESCRIPTION
## Summary
- Clarify that `AttributionProvider.ONESIGNAL_ID` should contain the OneSignal User ID.
- Add the changelog note for the SDK documentation clarification.

## Validation
- Ran staged whitespace checks with `git diff --cached --check`.
- Not run: builds, tests, or lint per repo preference.