### PR TITLE
Add loading color changing support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,12 @@ The changelog for `Superwall`. Also see the [releases](https://github.com/superw
 
 ## 2.7.20
 
-## Fixes
+## Enhancements
 
 - Adds `storeFrontCountryCode` property
+- Adds `PaywallOptions.loadingColor` to options enabling you to theme the circular progress bar 
+
+## Fixes
 - Fix a bug causing web redemption entitlements to be ignored in restoration tracking logic for users of purchase controller
 
 ## 2.7.19

--- a/superwall/src/main/java/com/superwall/sdk/config/options/PaywallOptions.kt
+++ b/superwall/src/main/java/com/superwall/sdk/config/options/PaywallOptions.kt
@@ -1,5 +1,6 @@
 package com.superwall.sdk.config.options
 
+import androidx.annotation.ColorRes
 import com.superwall.sdk.analytics.Tier
 import com.superwall.sdk.paywall.presentation.PaywallInfo
 import kotlin.time.Duration
@@ -135,6 +136,17 @@ class PaywallOptions() {
      * **Note:** This feature is still in development and could change.
      */
     var transactionBackgroundView: TransactionBackgroundView? = TransactionBackgroundView.SPINNER
+
+    /**
+     * A color resource used to tint the spinner shown while a purchase or restoration
+     * is in progress. Defaults to `null`, which keeps the system's default spinner color.
+     *
+     * Note: this only applies to the SDK's built-in loading view. If you present paywalls
+     * yourself and pass a custom view via `PaywallBuilder.purchaseLoadingView`, style that
+     * view directly instead.
+     */
+    @ColorRes
+    var loadingColor: Int? = null
 
     /** Hide shimmer optimistically. */
     var optimisticLoading: Boolean = false

--- a/superwall/src/main/java/com/superwall/sdk/dependencies/DependencyContainer.kt
+++ b/superwall/src/main/java/com/superwall/sdk/dependencies/DependencyContainer.kt
@@ -894,7 +894,13 @@ class DependencyContainer(
     }
 
     override fun makeCache(): PaywallViewCache =
-        PaywallViewCache(context, makeViewStore(), activityProvider!!, deviceHelper)
+        PaywallViewCache(
+            context,
+            makeViewStore(),
+            activityProvider!!,
+            deviceHelper,
+            configManager.options.paywalls.loadingColor,
+        )
 
     override fun activePaywallId(): String? =
         paywallManager.currentView

--- a/superwall/src/main/java/com/superwall/sdk/paywall/manager/PaywallViewCache.kt
+++ b/superwall/src/main/java/com/superwall/sdk/paywall/manager/PaywallViewCache.kt
@@ -1,6 +1,7 @@
 package com.superwall.sdk.paywall.manager
 
 import android.content.Context
+import androidx.annotation.ColorRes
 import com.superwall.sdk.misc.ActivityProvider
 import com.superwall.sdk.models.paywall.PaywallIdentifier
 import com.superwall.sdk.network.device.DeviceHelper
@@ -20,11 +21,12 @@ class PaywallViewCache(
     private val store: ViewStorage,
     private val activityProvider: ActivityProvider,
     private val deviceHelper: DeviceHelper,
+    @ColorRes private val loadingColor: Int? = null,
 ) {
     private val ctx: Context
         get() = activityProvider.getCurrentActivity() ?: appCtx
     private var _activePaywallVcKey: String? = null
-    private val loadingView: LoadingView = LoadingView(context = ctx)
+    private val loadingView: LoadingView = LoadingView(context = ctx, loadingColor = loadingColor)
     private val shimmerView: ShimmerView = ShimmerView(context = ctx)
 
     init {
@@ -70,7 +72,7 @@ class PaywallViewCache(
         return store.retrieveView(LoadingView.TAG)?.let {
             it as PaywallPurchaseLoadingView
         } ?: run {
-            val view = LoadingView(ctx)
+            val view = LoadingView(ctx, loadingColor = loadingColor)
             store.storeView(LoadingView.TAG, view)
             return view
         }

--- a/superwall/src/main/java/com/superwall/sdk/paywall/presentation/get_paywall/builder/PaywallBuilder.kt
+++ b/superwall/src/main/java/com/superwall/sdk/paywall/presentation/get_paywall/builder/PaywallBuilder.kt
@@ -91,7 +91,11 @@ class PaywallBuilder(
             .onSuccess { newView ->
                 newView.encapsulatingActivity = WeakReference(activity)
                 val shimmer = shimmmerView ?: ShimmerView(activity!!)
-                val loading = purchaseLoadingView ?: LoadingView(activity!!)
+                val loading =
+                    purchaseLoadingView ?: LoadingView(
+                        activity!!,
+                        loadingColor = Superwall.instance.options.paywalls.loadingColor,
+                    )
                 newView.setupWith(shimmer, loading)
                 newView.setupShimmer(shimmer)
                 newView.setupLoading(loading)
@@ -112,7 +116,11 @@ class PaywallBuilder(
                     .onSuccess { newView ->
                         newView.encapsulatingActivity = WeakReference(activity)
                         val shimmer = shimmmerView ?: ShimmerView(activity!!)
-                        val loading = purchaseLoadingView ?: LoadingView(activity!!)
+                        val loading =
+                    purchaseLoadingView ?: LoadingView(
+                        activity!!,
+                        loadingColor = Superwall.instance.options.paywalls.loadingColor,
+                    )
                         newView.setupWith(shimmer, loading)
                         newView.setupShimmer(shimmer)
                         newView.setupLoading(loading)
@@ -133,7 +141,11 @@ class PaywallBuilder(
                 .onSuccess { newView ->
                     newView.encapsulatingActivity = WeakReference(activity)
                     val shimmer = shimmmerView ?: ShimmerView(activity!!)
-                    val loading = purchaseLoadingView ?: LoadingView(activity!!)
+                    val loading =
+                    purchaseLoadingView ?: LoadingView(
+                        activity!!,
+                        loadingColor = Superwall.instance.options.paywalls.loadingColor,
+                    )
                     newView.setupWith(shimmer, loading)
                     newView.setupShimmer(shimmer)
                     newView.setupLoading(loading)

--- a/superwall/src/main/java/com/superwall/sdk/paywall/view/LoadingView.kt
+++ b/superwall/src/main/java/com/superwall/sdk/paywall/view/LoadingView.kt
@@ -1,6 +1,7 @@
 package com.superwall.sdk.paywall.view
 
 import android.content.Context
+import android.content.res.ColorStateList
 import android.graphics.Color
 import android.util.AttributeSet
 import android.view.Gravity
@@ -10,6 +11,8 @@ import android.widget.FrameLayout
 import android.widget.FrameLayout.GONE
 import android.widget.FrameLayout.VISIBLE
 import android.widget.ProgressBar
+import androidx.annotation.ColorRes
+import androidx.core.content.ContextCompat
 import com.superwall.sdk.paywall.view.delegate.PaywallLoadingState
 
 class LoadingView
@@ -19,6 +22,7 @@ class LoadingView
         attrs: AttributeSet? = null,
         defStyleAttr: Int = 0,
         defStyleRes: Int = 0,
+        @ColorRes loadingColor: Int? = null,
     ) : FrameLayout(context.applicationContext),
         PaywallPurchaseLoadingView {
         companion object {
@@ -40,6 +44,10 @@ class LoadingView
                             Gravity.CENTER,
                         )
                     layoutParams = params
+                    loadingColor?.let {
+                        indeterminateTintList =
+                            ColorStateList.valueOf(ContextCompat.getColor(context, it))
+                    }
                 }
 
             // Add the ProgressBar to this view

--- a/superwall/src/main/java/com/superwall/sdk/paywall/view/PaywallView.kt
+++ b/superwall/src/main/java/com/superwall/sdk/paywall/view/PaywallView.kt
@@ -691,7 +691,6 @@ class PaywallView(
     private fun hideLoadingView() {
         loadingView?.let {
             mainScope.launch {
-                it.hideLoading()
             }
         }
     }
@@ -728,8 +727,10 @@ class PaywallView(
         shimmerView?.let {
             mainScope.launch {
                 it.hideShimmer()
+                showLoadingView()
             }
         }
+
         // Guard against duplicate tracking
         if (state.paywall.shimmerLoadingInfo.endAt != null) return
 

--- a/superwall/src/main/java/com/superwall/sdk/paywall/view/PaywallView.kt
+++ b/superwall/src/main/java/com/superwall/sdk/paywall/view/PaywallView.kt
@@ -691,6 +691,7 @@ class PaywallView(
     private fun hideLoadingView() {
         loadingView?.let {
             mainScope.launch {
+                it.hideLoading()
             }
         }
     }
@@ -727,7 +728,6 @@ class PaywallView(
         shimmerView?.let {
             mainScope.launch {
                 it.hideShimmer()
-                showLoadingView()
             }
         }
 


### PR DESCRIPTION
## Changes in this pull request

- Adds `PaywallOptions.loadingColor` to options enabling you to theme the circular progress bar 

### Checklist

- [ ] All unit tests pass.
- [ ] All UI tests pass.
- [ ] Demo project builds and runs.
- [ ] I added/updated tests or detailed why my change isn't tested.
- [ ] I added an entry to the `CHANGELOG.md` for any breaking changes, enhancements, or bug fixes.
- [ ] I have run `ktlint` in the main directory and fixed any issues.
- [ ] I have updated the SDK documentation as well as the online docs.
- [ ] I have reviewed the [contributing guide](https://github.com/superwall/Superwall-Android/tree/master/.github/CONTRIBUTING.md)