### PR TITLE
Guard SequentialActor consumer loop so a throwing action cannot crash the app

### DIFF
--- a/superwall/src/main/java/com/superwall/sdk/misc/primitives/ActorTypes.kt
+++ b/superwall/src/main/java/com/superwall/sdk/misc/primitives/ActorTypes.kt
@@ -1,5 +1,6 @@
 package com.superwall.sdk.misc.primitives
 
+import com.superwall.sdk.utilities.withErrorTracking
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -31,10 +32,15 @@ class SequentialActor<Context, S>(
     }
 
     init {
-        // Single consumer — FIFO ordering guaranteed.
+        // Single consumer — FIFO ordering guaranteed. Each unit of work is
+        // guarded: a throwing action must neither kill this loop (silently
+        // halting every subsequent action) nor escape to the scope, which may
+        // have no CoroutineExceptionHandler and would crash the app (e.g. a
+        // failing billing fetch inside CheckWebEntitlements). Failures are
+        // recorded via error tracking, matching the SuperwallScope handlers.
         scope.launch(OwnerElement(this@SequentialActor)) {
             for (work in queue) {
-                work()
+                withErrorTracking { work() }
             }
         }
     }

--- a/superwall/src/test/java/com/superwall/sdk/misc/primitives/SequentialActorTest.kt
+++ b/superwall/src/test/java/com/superwall/sdk/misc/primitives/SequentialActorTest.kt
@@ -1,0 +1,87 @@
+package com.superwall.sdk.misc.primitives
+
+import com.superwall.sdk.And
+import com.superwall.sdk.Given
+import com.superwall.sdk.Then
+import com.superwall.sdk.When
+import kotlinx.coroutines.CoroutineExceptionHandler
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class SequentialActorTest {
+    private fun action(block: suspend () -> Unit) =
+        object : TypedAction<Unit> {
+            override val execute: suspend Unit.() -> Unit = { block() }
+        }
+
+    @Test
+    fun `throwing effect action does not escape the scope or kill the consumer loop`() =
+        runTest {
+            Given("a SequentialActor running on a scope without a handler-bearing SuperwallScope") {
+                var uncaught: Throwable? = null
+                val handler = CoroutineExceptionHandler { _, e -> uncaught = e }
+                val scope =
+                    CoroutineScope(SupervisorJob() + StandardTestDispatcher(testScheduler) + handler)
+                val actor = SequentialActor<Unit, Int>(0, scope)
+
+                When("an effect action throws and another action follows") {
+                    var laterActionRan = false
+                    actor.effect(Unit, action { error("boom") })
+                    actor.effect(Unit, action { laterActionRan = true })
+                    advanceUntilIdle()
+
+                    Then("the exception does not escape to the scope") {
+                        assertNull(uncaught)
+                    }
+                    And("the consumer loop is still alive and runs subsequent actions") {
+                        assertTrue(laterActionRan)
+                    }
+                }
+                actor.close()
+            }
+        }
+
+    @Test
+    fun `throwing immediate action still rethrows to the caller`() =
+        runTest {
+            Given("a SequentialActor") {
+                val scope = CoroutineScope(SupervisorJob() + StandardTestDispatcher(testScheduler))
+                val actor = SequentialActor<Unit, Int>(0, scope)
+
+                When("an immediate action throws") {
+                    var thrown: Throwable? = null
+                    val caller =
+                        launch {
+                            try {
+                                actor.immediate(Unit, action { error("boom") })
+                            } catch (e: IllegalStateException) {
+                                thrown = e
+                            }
+                        }
+                    advanceUntilIdle()
+                    caller.join()
+
+                    Then("the caller receives the exception") {
+                        assertEquals("boom", thrown?.message)
+                    }
+                    And("the consumer loop still runs subsequent actions") {
+                        var laterActionRan = false
+                        actor.effect(Unit, action { laterActionRan = true })
+                        advanceUntilIdle()
+                        assertTrue(laterActionRan)
+                    }
+                }
+                actor.close()
+            }
+        }
+}


### PR DESCRIPTION
Fixes #439

## Problem

A fire-and-forget actor action that throws — in production for us, `Actions.CheckWebEntitlements` failing with `BillingError.BillingNotAvailable` when Play Billing returns `NETWORK_ERROR` after retries — escapes `SequentialActor`'s consumer loop into the actor's scope. The default scope is a plain `CoroutineScope(Dispatchers.IO)` with no `CoroutineExceptionHandler`, so the exception kills the process (~550 crashed users/week in our production app). It also terminates the FIFO consumer, so every subsequent identity action (attribute merges, assignment fetches, entitlement checks) is silently dropped for the rest of the session.

Full root-cause walkthrough with file/line references is in #439.

## Fix

Wrap each unit of work in the consumer loop in `withErrorTracking`, matching the behavior of the `SuperwallScope` exception handlers used elsewhere in the SDK:

- A throwing `effect()` action is recorded via error tracking and the loop keeps processing — no app crash, no dead actor.
- `immediate()` callers still receive exceptions unchanged: the enqueued work item already routes them through `CompletableDeferred.completeExceptionally`, so the loop-level guard never sees them.
- Cancellation is unaffected in practice: `withErrorTracking` does not report `CancellationException` (`shouldLog()` excludes it), and a cancelled scope exits the loop on the next channel receive — the same behavior `launchWithTracking` bodies have today.

## Tests

New `SequentialActorTest`:

- `throwing effect action does not escape the scope or kill the consumer loop` — fails before this change (the exception reaches the scope's `CoroutineExceptionHandler` and the follow-up action never runs), passes after.
- `throwing immediate action still rethrows to the caller` — guards the preserved `immediate()` semantics; passes before and after.

`./gradlew :superwall:testDebugUnitTest` (full module suite) passes.

